### PR TITLE
Task execution order

### DIFF
--- a/src/core/plan/call-planner.ts
+++ b/src/core/plan/call-planner.ts
@@ -41,17 +41,26 @@ export interface ZCallPlanner<TAction extends ZTaskSpec.Action> {
   call<TAction extends ZTaskSpec.Action>(instruction: ZCallInstruction<TAction>): Promise<ZCall<TAction>>;
 
   /**
-   * Make a task require another one.
+   * Sets the task execution order.
    *
-   * @param dependent  Dependent task.
-   * @param dependency  Dependency task.
+   * The call to this method does not cause any of the tasks to be executed.
+   *
+   * When any of the tasks executed it first executes its prerequisites. I.e. the tasks ordered before it.
+   * The task itself will be executed only after each prerequisite completes, unless that prerequisite can be executed
+   * {@link makeParallel in parallel}.
+   *
+   * Contradictory execution order makes tasks effectively parallel.
+   *
+   * @param tasks  Array of tasks in order of their execution.
    */
-  require(dependent: ZTask, dependency: ZTask): void;
+  order(tasks: readonly ZTask[]): void;
 
   /**
    * Allow parallel tasks execution.
    *
-   * @param tasks  Tasks that can be executed in parallel to each other.
+   * The call to this method does not cause any of the tasks to be executed.
+   *
+   * @param tasks  Array of tasks that can be executed in parallel to each other.
    */
   makeParallel(tasks: readonly ZTask[]): void;
 

--- a/src/core/plan/call.ts
+++ b/src/core/plan/call.ts
@@ -31,24 +31,35 @@ export interface ZCall<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> {
   params(): ZTaskParams;
 
   /**
-   * Returns this task execution dependencies.
+   * Returns immediate prerequisites of this task.
    *
-   * @returns An iterable of required task execution calls.
+   * @returns An iterable of task execution calls to make before this one.
    *
-   * @see ZCallPlanner.require
+   * @see ZCallPlanner.order
    */
-  required(): Iterable<ZCall>;
+  prerequisites(): Iterable<ZCall>;
 
   /**
-   * Whether this task call can be executed in parallel with the a call to another task.
+   * Checks whether a call to the given task is a prerequisite of this one.
    *
-   * @param other  The task to check.
+   * Checks recursively among all immediate and deep prerequisites.
    *
-   * @returns `true` is tasks can be executed in parallel, or `false` otherwise.
+   * @param task  The task to check.
+   *
+   * @returns `true` if the given `task` is {@link ZCallPlanner.order ordered} before this one, or `false` otherwise.
+   */
+  hasPrerequisite(task: ZTask): boolean;
+
+  /**
+   * Checks whether this task call can be executed in parallel to a call to the given task.
+   *
+   * @param task  The task to check.
+   *
+   * @returns `true` if tasks can be executed in parallel, or `false` otherwise.
    *
    * @see ZCallPlanner.makeParallel
    */
-  parallelWith(other: ZTask): boolean;
+  isParallelTo(task: ZTask): boolean;
 
   /**
    * Extends this call parameters with the given extension.

--- a/src/core/plan/plan.spec.ts
+++ b/src/core/plan/plan.spec.ts
@@ -1,4 +1,5 @@
-import { TestPlan } from '../../spec';
+import { prerequisitesOf, TestPlan } from '../../spec';
+import { taskIds } from '../../spec/task-id';
 import { UnknownZTaskError } from '../tasks';
 import type { ZCall } from './call';
 import type { ZPlan } from './plan';
@@ -75,7 +76,7 @@ describe('ZPlan', () => {
             const { task } = planner.plannedCall;
             const dep1 = task.target.task('dep1');
 
-            planner.require(task, dep1);
+            planner.order([dep1, task]);
           },
         },
     );
@@ -85,7 +86,7 @@ describe('ZPlan', () => {
 
     const dep2 = plan.callOf(target.task('dep2'));
 
-    expect([...call.required()]).toEqual([dep2]);
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep2));
   });
   it('allows explicit parallel execution', async () => {
     testPlan.addPackage(
@@ -119,8 +120,8 @@ describe('ZPlan', () => {
     const dep1 = target.task('dep1');
     const dep2 = target.task('dep2');
 
-    expect(call.parallelWith(dep1)).toBe(true);
-    expect(call.parallelWith(dep2)).toBe(true);
-    expect(plan.callOf(dep1).parallelWith(dep2)).toBe(true);
+    expect(call.isParallelTo(dep1)).toBe(true);
+    expect(call.isParallelTo(dep2)).toBe(true);
+    expect(plan.callOf(dep1).isParallelTo(dep2)).toBe(true);
   });
 });

--- a/src/core/plan/planner.impl.ts
+++ b/src/core/plan/planner.impl.ts
@@ -130,21 +130,12 @@ export class ZInstructionRecords {
       return true;
     }
     for (const prerequisite of prerequisites) {
-      this.isPrerequisiteOf(prerequisite, toCheck, checked);
+      if (this.isPrerequisiteOf(prerequisite, toCheck, checked)) {
+        return true;
+      }
     }
 
     return false;
-  }
-
-  prerequisiteSetOf(dependent: ZTask): ReadonlySet<ZTask> {
-
-    const prerequisites = this._prerequisites.get(dependent);
-
-    if (!prerequisites) {
-      return new Set();
-    }
-
-    return prerequisites;
   }
 
   makeParallel(tasks: readonly ZTask[]): void {

--- a/src/core/tasks/impl/group.task.spec.ts
+++ b/src/core/tasks/impl/group.task.spec.ts
@@ -224,16 +224,16 @@ describe('GroupZTask', () => {
     const sub1 = plan.callOf(nested1.task('sub-task'));
     const sub2 = plan.callOf(nested2.task('sub-task'));
 
-    expect(prerequisitesOf(call)).toEqual(taskIds(sub1));
+    expect(prerequisitesOf(call)).toEqual(taskIds(sub2));
     expect(call.params().attrs).toEqual({ attr1: ['on'] });
 
     expect(prerequisitesOf(dep)).toEqual([{ target: 'nested2', task: 'dep3' }]);
     expect(dep.params().attrs).toEqual({ attr1: ['on'] });
 
-    expect(prerequisitesOf(sub1)).toEqual(taskIds(sub2));
+    expect(prerequisitesOf(sub1)).toEqual(taskIds(dep));
     expect(sub1.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
 
-    expect(prerequisitesOf(sub2)).toEqual(taskIds(dep));
+    expect(prerequisitesOf(sub2)).toEqual(taskIds(sub1));
     expect(sub2.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
   });
 });

--- a/src/core/tasks/impl/group.task.spec.ts
+++ b/src/core/tasks/impl/group.task.spec.ts
@@ -1,4 +1,4 @@
-import { TestPlan } from '../../../spec';
+import { prerequisitesOf, taskIds, TestPlan } from '../../../spec';
 import { GroupZTask } from './group.task';
 
 describe('GroupZTask', () => {
@@ -30,11 +30,13 @@ describe('GroupZTask', () => {
     const dep1 = plan.callOf(target.task('dep1'));
     const dep2 = plan.callOf(target.task('dep2'));
 
-    expect([...call.required()]).toEqual([dep1]);
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep1));
     expect(call.params().attrs).toEqual({ test: ['1'] });
-    expect([...dep1.required()]).toEqual([dep2]);
+
+    expect(prerequisitesOf(dep1)).toEqual(taskIds(dep2));
     expect(dep1.params().attrs).toEqual({ test: ['1'], dep1: ['2'] });
-    expect([...dep2.required()]).toHaveLength(0);
+
+    expect(prerequisitesOf(dep2)).toHaveLength(0);
     expect(dep2.params().attrs).toEqual({ test: ['1'], dep1: ['2'] });
   });
 
@@ -58,13 +60,16 @@ describe('GroupZTask', () => {
     const dep2 = plan.callOf(target.task('dep2'));
     const dep3 = plan.callOf(target.task('dep3'));
 
-    expect([...call.required()]).toEqual([dep1, dep3]);
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep3));
     expect(call.params().attrs).toEqual({ attr2: ['on'] });
-    expect([...dep1.required()]).toEqual([dep2]);
+
+    expect(prerequisitesOf(dep1)).toEqual(taskIds(dep2));
     expect(dep1.params().attrs).toEqual({ attr2: ['on'] });
-    expect([...dep2.required()]).toHaveLength(0);
+
+    expect(prerequisitesOf(dep2)).toHaveLength(0);
     expect(dep2.params().attrs).toEqual({ attr2: ['on'] });
-    expect([...dep3.required()]).toHaveLength(0);
+
+    expect(prerequisitesOf(dep3)).toEqual(taskIds(dep1));
     expect(dep3.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
   });
 
@@ -108,9 +113,13 @@ describe('GroupZTask', () => {
     const dep1 = plan.callOf(nested1.task('dep'));
     const dep2 = plan.callOf(nested2.task('dep'));
 
-    expect([...call.required()]).toEqual([dep1, dep2]);
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep2));
     expect(call.params().attrs).toEqual({ attr2: ['on'] });
+
+    expect(prerequisitesOf(dep1)).toHaveLength(0);
     expect(dep1.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'], attr3: ['1'] });
+
+    expect(prerequisitesOf(dep2)).toEqual(taskIds(dep1));
     expect(dep2.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'], attr3: ['2'] });
   });
 
@@ -158,11 +167,19 @@ describe('GroupZTask', () => {
     const dep2 = plan.callOf(nested2.task('dep'));
     const sub2 = plan.callOf(nested2.task('sub-task'));
 
-    expect([...call.required()]).toEqual([dep1, sub1, dep2, sub2]);
+    expect(prerequisitesOf(call)).toEqual(taskIds(sub2));
     expect(call.params().attrs).toEqual({ attr1: ['on'] });
+
+    expect(prerequisitesOf(dep1)).toHaveLength(0);
     expect(dep1.params().attrs).toEqual({ attr1: ['on'], attr3: ['1'] });
+
+    expect(prerequisitesOf(sub1)).toEqual(taskIds(dep1));
     expect(sub1.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
+
+    expect(prerequisitesOf(dep2)).toEqual(taskIds(sub1));
     expect(dep2.params().attrs).toEqual({ attr1: ['on'], attr3: ['2'] });
+
+    expect(prerequisitesOf(sub2)).toEqual(taskIds(dep2));
     expect(sub2.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
   });
 
@@ -207,10 +224,16 @@ describe('GroupZTask', () => {
     const sub1 = plan.callOf(nested1.task('sub-task'));
     const sub2 = plan.callOf(nested2.task('sub-task'));
 
-    expect([...call.required()]).toEqual([dep, sub2, sub1]);
+    expect(prerequisitesOf(call)).toEqual(taskIds(sub1));
     expect(call.params().attrs).toEqual({ attr1: ['on'] });
+
+    expect(prerequisitesOf(dep)).toEqual([{ target: 'nested2', task: 'dep3' }]);
     expect(dep.params().attrs).toEqual({ attr1: ['on'] });
+
+    expect(prerequisitesOf(sub1)).toEqual(taskIds(sub2));
     expect(sub1.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
+
+    expect(prerequisitesOf(sub2)).toEqual(taskIds(dep));
     expect(sub2.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
   });
 });

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -55,7 +55,7 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
 
         const selected = target.select(dep.selector);
 
-        result = result ? result.andPackages(selected) : selected;
+        result = result ? selected.andPackages(result) : selected;
       } else if (result) {
         break;
       }

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -1,1 +1,2 @@
+export * from './task-id';
 export * from './test-plan';

--- a/src/spec/task-id.ts
+++ b/src/spec/task-id.ts
@@ -1,0 +1,38 @@
+import { isIterable } from '@proc7ts/primitives';
+import type { ZCall } from '../core/plan';
+import type { ZTask } from '../core/tasks';
+
+export interface TaskId {
+  readonly target: string;
+  readonly task: string;
+}
+
+export function taskId(value: ZTask | ZCall): TaskId {
+
+  const task = isCall(value) ? value.task : value;
+
+  return { target: task.target.name, task: task.name };
+}
+
+function isCall(value: ZTask | ZCall): value is ZCall {
+  return 'task' in value;
+}
+
+export function taskIds(values: Iterable<ZTask | ZCall>): readonly TaskId[];
+export function taskIds(...values: (ZTask | ZCall)[]): readonly TaskId[];
+export function taskIds(...values: [Iterable<ZTask | ZCall>] | (ZTask | ZCall)[]): readonly TaskId[] {
+
+  let items: Iterable<ZTask | ZCall>;
+
+  if (values.length === 1 && isIterable(values[0])) {
+    items = values[0];
+  } else {
+    items = values as Iterable<ZTask | ZCall>;
+  }
+
+  return Array.from(items, taskId);
+}
+
+export function prerequisitesOf(call: ZCall): readonly TaskId[] {
+  return taskIds(call.prerequisites());
+}


### PR DESCRIPTION
- Order task execution with `ZCallPlanner.order()`
- Detect deep call prerequisite with `ZCall.hasPrerequisite()` method.
- Handle contradictory (recurrent) execution order.