### PR TITLE
Task prerequisites

### DIFF
--- a/src/core/packages/package-set.ts
+++ b/src/core/packages/package-set.ts
@@ -49,4 +49,8 @@ class CombinedZPackageSet extends ZPackageSet {
     return new CombinedZPackageSet([...this.sets, other]);
   }
 
+  toString(): string {
+    return this.sets.join(' ');
+  }
+
 }

--- a/src/core/packages/package.ts
+++ b/src/core/packages/package.ts
@@ -147,7 +147,7 @@ export class ZPackage extends ZPackageSet {
    * @returns Selected package set.
    */
   select(selector: string): ZPackageSet {
-    return new ResolvedZPackages(this, selector);
+    return new SelectedZPackages(this, selector);
   }
 
   task(name: string): ZTask {
@@ -165,12 +165,16 @@ export class ZPackage extends ZPackageSet {
     return absent;
   }
 
+  toString(): string {
+    return this.name;
+  }
+
 }
 
 /**
  * @internal
  */
-class ResolvedZPackages extends ZPackageSet {
+class SelectedZPackages extends ZPackageSet {
 
   constructor(readonly pkg: ZPackage, readonly selector: string) {
     super();
@@ -185,6 +189,10 @@ class ResolvedZPackages extends ZPackageSet {
         yield resolved;
       }
     }
+  }
+
+  toString(): string {
+    return this.selector;
   }
 
 }

--- a/src/core/plan/call-planner.ts
+++ b/src/core/plan/call-planner.ts
@@ -14,7 +14,7 @@ import type { ZCallInstruction } from './call-instruction';
  *
  * @typeparam TAction  Task action type.
  */
-export interface ZCallPlanner<TAction extends ZTaskSpec.Action> {
+export interface ZCallPlanner<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> {
 
   /**
    * Task execution setup instance.
@@ -41,7 +41,7 @@ export interface ZCallPlanner<TAction extends ZTaskSpec.Action> {
   call<TAction extends ZTaskSpec.Action>(instruction: ZCallInstruction<TAction>): Promise<ZCall<TAction>>;
 
   /**
-   * Sets the task execution order.
+   * Establishes the task execution order.
    *
    * The call to this method does not cause any of the tasks to be executed.
    *
@@ -51,9 +51,10 @@ export interface ZCallPlanner<TAction extends ZTaskSpec.Action> {
    *
    * Contradictory execution order causes one of the tasks to be executed before prerequisite.
    *
-   * @param tasks  Array of tasks in order of their execution.
+   * @param first  The task executed first.
+   * @param second  The task executed after the first one.
    */
-  order(tasks: readonly ZTask[]): void;
+  order(first: ZTask, second: ZTask): void;
 
   /**
    * Allow parallel tasks execution.

--- a/src/core/plan/call-planner.ts
+++ b/src/core/plan/call-planner.ts
@@ -3,7 +3,7 @@
  * @module run-z
  */
 import type { ZSetup } from '../setup';
-import type { ZTask, ZTaskSpec } from '../tasks';
+import type { ZTask, ZTaskQualifier, ZTaskSpec } from '../tasks';
 import type { ZCall } from './call';
 import type { ZCallInstruction } from './call-instruction';
 
@@ -27,6 +27,16 @@ export interface ZCallPlanner<TAction extends ZTaskSpec.Action = ZTaskSpec.Actio
    * All instructions recorded by this planner are related to this call.
    */
   readonly plannedCall: ZCall<TAction>;
+
+  /**
+   * Qualifies the task.
+   *
+   * Add the given qualifier to the task.
+   *
+   * @param task  Target task to add qualifier to.
+   * @param qualifier  Qualifier to add to the task.
+   */
+  qualify(task: ZTask, qualifier: ZTaskQualifier): void;
 
   /**
    * Records a call to a task.
@@ -61,8 +71,8 @@ export interface ZCallPlanner<TAction extends ZTaskSpec.Action = ZTaskSpec.Actio
    *
    * The call to this method does not cause any of the tasks to be executed.
    *
-   * @param tasks  Array of tasks that can be executed in parallel to each other.
+   * @param tasks  Array of qualifiers of the tasks that can be executed in parallel to each other.
    */
-  makeParallel(tasks: readonly ZTask[]): void;
+  makeParallel(tasks: readonly ZTaskQualifier[]): void;
 
 }

--- a/src/core/plan/call.impl.ts
+++ b/src/core/plan/call.impl.ts
@@ -95,6 +95,7 @@ export class ZCallRecord<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> im
     await instruction.plan({
       setup: this._records.setup,
       plannedCall: this,
+      qualify: this._records.qualify.bind(this._records),
       call: instr => this._records.call(instr, this),
       order: this._records.order.bind(this._records),
       makeParallel: this._records.makeParallel.bind(this._records),

--- a/src/core/plan/call.spec.ts
+++ b/src/core/plan/call.spec.ts
@@ -23,7 +23,7 @@ describe('ZCall', () => {
     };
 
     const spec: ZTaskSpec = {
-      deps: [],
+      pre: [],
       attrs: initParams.attrs,
       args: initParams.args,
       action: {

--- a/src/core/plan/plan.spec.ts
+++ b/src/core/plan/plan.spec.ts
@@ -79,7 +79,7 @@ describe('ZPlan', () => {
             const { task } = planner.plannedCall;
             const dep1 = task.target.task('dep1');
 
-            planner.order([dep1, task]);
+            planner.order(dep1, task);
           },
         },
     );

--- a/src/core/plan/plan.spec.ts
+++ b/src/core/plan/plan.spec.ts
@@ -57,7 +57,7 @@ describe('ZPlan', () => {
     expect(dep2.params().args).toEqual(['--arg2', '--arg1']);
     expect(dep2.params().attr('attr')).toBe('1');
   });
-  it('ignores never called dependencies', async () => {
+  it('ignores never called prerequisites', async () => {
     testPlan.addPackage(
         'test',
         {

--- a/src/core/plan/planner.impl.ts
+++ b/src/core/plan/planner.impl.ts
@@ -42,18 +42,15 @@ export class ZInstructionRecords {
     };
   }
 
-  qualify(task: ZTask, qualifier: ZTaskQualifier): Set<ZTaskQualifier> {
+  qualify(task: ZTask, qualifier: ZTaskQualifier): void {
 
-    let qualifiers = this._qualifiers.get(task);
+    const qualifiers = this._qualifiers.get(task);
 
     if (qualifiers) {
       qualifiers.add(qualifier);
     } else {
-      qualifiers = new Set<ZTaskQualifier>().add(task).add(qualifier);
-      this._qualifiers.set(task, qualifiers);
+      this._qualifiers.set(task, new Set<ZTaskQualifier>().add(task).add(qualifier));
     }
-
-    return qualifiers;
   }
 
   private _qualifiersOf(task: ZTask): Iterable<ZTaskQualifier> {

--- a/src/core/plan/planner.impl.ts
+++ b/src/core/plan/planner.impl.ts
@@ -62,18 +62,13 @@ export class ZInstructionRecords {
     return call;
   }
 
-  order(tasks: readonly ZTask[]): void {
-    for (let i = tasks.length - 1; i > 0; --i) {
+  order(first: ZTask, second: ZTask): void {
+    const prerequisites = this._prerequisites.get(second);
 
-      const next = tasks[i];
-      const prev = tasks[i - 1];
-      const prerequisites = this._prerequisites.get(next);
-
-      if (prerequisites) {
-        prerequisites.add(prev);
-      } else {
-        this._prerequisites.set(next, new Set<ZTask>().add(prev));
-      }
+    if (prerequisites) {
+      prerequisites.add(first);
+    } else {
+      this._prerequisites.set(second, new Set<ZTask>().add(first));
     }
   }
 

--- a/src/core/plan/planner.ts
+++ b/src/core/plan/planner.ts
@@ -24,7 +24,7 @@ export class ZPlanner {
   /**
    * Builds a task execution plan.
    *
-   * The plan would execute the task after executing all of its dependencies.
+   * The plan would execute the task after executing all of its prerequisites.
    *
    * @typeparam TAction  Task action type.
    * @param instruction  Top-level task call instruction.

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -16,6 +16,10 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
   ) {
   }
 
+  get taskQN(): string {
+    return this.name;
+  }
+
   params(): ZTaskParams.Partial {
 
     const { spec: { attrs, args } } = this;

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -45,14 +45,17 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
   protected async planDeps(planner: ZCallPlanner<TAction>): Promise<void> {
 
     const { target, spec } = this;
+    let hasTasks = false;
     let targets: ZPackageSet | undefined;
     let parallel: ZTaskQualifier[] = [];
     let prevTasks: ZTask[] = [];
 
     for (const pre of spec.pre) {
       if (pre.selector != null) {
-        targets = selectZTaskPreTargets(target, targets, pre);
+        targets = selectZTaskPreTargets(target, hasTasks ? undefined : targets, pre);
+        hasTasks = false;
       } else {
+        hasTasks = true;
         if (!pre.parallel) {
           planner.makeParallel(parallel);
           parallel = [];
@@ -89,7 +92,6 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
         }
 
         prevTasks = calledTasks;
-        targets = undefined;
       }
     }
 

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -27,7 +27,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
     await this.planDeps(planner);
   }
 
-  asDepOf(
+  asPre(
       dependent: ZCall,
       { attrs, args }: ZTaskSpec.TaskRef,
   ): Iterable<ZCallInstruction> | AsyncIterable<ZCallInstruction> {
@@ -47,7 +47,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
     let parallel: ZTask[] = [];
     const order: ZTask[] = [];
 
-    for (const dep of spec.deps) {
+    for (const dep of spec.pre) {
       if (dep.selector != null) {
         targets = updateZTaskDepTargets(target, targets, dep);
       } else {
@@ -59,7 +59,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
         const depTasks = await resolveZTaskRef(targets || target, dep);
 
         for (const depTask of depTasks) {
-          for await (const subTaskCall of depTask.asDepOf(plannedCall, dep)) {
+          for await (const subTaskCall of depTask.asPre(plannedCall, dep)) {
             await planner.call(subTaskCall);
             order.push(subTaskCall.task);
             parallel.push(subTaskCall.task);
@@ -80,7 +80,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
   }
 
   /**
-   * Whether this task can be called in parallel to dependencies.
+   * Whether this task can be called in parallel to its prerequisites.
    */
   protected isParallel(): boolean {
     return false;

--- a/src/core/tasks/impl/command.task.spec.ts
+++ b/src/core/tasks/impl/command.task.spec.ts
@@ -32,7 +32,7 @@ describe('CommandZTask', () => {
     expect(params.actionArgs).toEqual(['--cmd']);
   });
 
-  it('calls dependencies', async () => {
+  it('calls prerequisites', async () => {
     testPlan.addPackage(
         'test',
         {
@@ -51,7 +51,7 @@ describe('CommandZTask', () => {
     expect(prerequisitesOf(call)).toEqual(taskIds([dep]));
     expect(dep.params().attrs).toEqual({ attr: ['on'] });
   });
-  it('calls parallel dependencies', async () => {
+  it('calls parallel prerequisites', async () => {
     testPlan.addPackage(
         'test',
         {
@@ -80,7 +80,7 @@ describe('CommandZTask', () => {
     expect(prerequisitesOf(dep2)).toEqual(taskIds(dep1));
     expect(dep2.isParallelTo(dep1.task)).toBe(true);
   });
-  it('executed parallel with dependencies', async () => {
+  it('executed parallel with prerequisites', async () => {
     testPlan.addPackage(
         'test',
         {

--- a/src/core/tasks/impl/group.task.spec.ts
+++ b/src/core/tasks/impl/group.task.spec.ts
@@ -123,13 +123,13 @@ describe('GroupZTask', () => {
     const dep1 = plan.callOf(nested1.task('dep'));
     const dep2 = plan.callOf(nested2.task('dep'));
 
-    expect(prerequisitesOf(call)).toEqual(taskIds(dep2));
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep1, dep2));
     expect(call.params().attrs).toEqual({ attr2: ['on'] });
 
     expect(prerequisitesOf(dep1)).toHaveLength(0);
     expect(dep1.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'], attr3: ['1'] });
 
-    expect(prerequisitesOf(dep2)).toEqual(taskIds(dep1));
+    expect(prerequisitesOf(dep2)).toHaveLength(0);
     expect(dep2.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'], attr3: ['2'] });
   });
 
@@ -183,7 +183,7 @@ describe('GroupZTask', () => {
     const dep2 = plan.callOf(nested2.task('dep'));
     const sub2 = plan.callOf(nested2.task('sub-task'));
 
-    expect(prerequisitesOf(call)).toEqual(taskIds(sub2));
+    expect(prerequisitesOf(call)).toEqual(taskIds(sub1, sub2));
     expect(call.params().attrs).toEqual({ attr1: ['on'] });
 
     expect(prerequisitesOf(dep1)).toHaveLength(0);
@@ -192,7 +192,7 @@ describe('GroupZTask', () => {
     expect(prerequisitesOf(sub1)).toEqual(taskIds(dep1));
     expect(sub1.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
 
-    expect(prerequisitesOf(dep2)).toEqual(taskIds(sub1));
+    expect(prerequisitesOf(dep2)).toHaveLength(0);
     expect(dep2.params().attrs).toEqual({ attr1: ['on'], attr3: ['2'] });
 
     expect(prerequisitesOf(sub2)).toEqual(taskIds(dep2));
@@ -246,16 +246,19 @@ describe('GroupZTask', () => {
     const sub1 = plan.callOf(nested1.task('sub-task'));
     const sub2 = plan.callOf(nested2.task('sub-task'));
 
-    expect(prerequisitesOf(call)).toEqual(taskIds(sub2));
+    expect(prerequisitesOf(call)).toEqual(taskIds(sub1, sub2));
     expect(call.params().attrs).toEqual({ attr1: ['on'] });
 
-    expect(prerequisitesOf(dep)).toEqual([{ target: 'nested2', task: 'dep3' }]);
+    expect(prerequisitesOf(dep)).toEqual([
+        { target: 'nested1', task: 'dep3' },
+        { target: 'nested2', task: 'dep3' },
+    ]);
     expect(dep.params().attrs).toEqual({ attr1: ['on'] });
 
     expect(prerequisitesOf(sub1)).toEqual(taskIds(dep));
     expect(sub1.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
 
-    expect(prerequisitesOf(sub2)).toEqual(taskIds(sub1));
+    expect(prerequisitesOf(sub2)).toEqual(taskIds(dep));
     expect(sub2.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
   });
 

--- a/src/core/tasks/impl/group.task.spec.ts
+++ b/src/core/tasks/impl/group.task.spec.ts
@@ -133,6 +133,64 @@ describe('GroupZTask', () => {
     expect(dep2.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'], attr3: ['2'] });
   });
 
+  it('calls parallel external prerequisites', async () => {
+
+    const targetLocation = testPlan.addPackage(
+        'test',
+        {
+          packageJson: {
+            scripts: {
+              test: 'run-z dep0, ./nested// dep',
+              dep0: 'exec',
+            },
+          },
+        },
+    );
+
+    testPlan.addPackage(
+        'test/nested/nested1',
+        {
+          packageJson: {
+            scripts: {
+              dep: 'run-z attr3=1 --then exec1',
+            },
+          },
+        },
+    );
+
+    const nested1 = await testPlan.target();
+
+    testPlan.addPackage(
+        'test/nested/nested2',
+        {
+          packageJson: {
+            scripts: {
+              dep: 'run-z attr3=2 --then exec2',
+            },
+          },
+        },
+    );
+
+    const nested2 = await testPlan.target();
+    const target = await testPlan.target(targetLocation);
+
+    const call = await testPlan.plan('test');
+    const plan = call.plan;
+    const dep0 = plan.callOf(target.task('dep0'));
+    const dep1 = plan.callOf(nested1.task('dep'));
+    const dep2 = plan.callOf(nested2.task('dep'));
+
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep1, dep2));
+
+    expect(prerequisitesOf(dep1)).toEqual(taskIds(dep0));
+    expect(dep1.isParallelTo(dep0.task)).toBe(true);
+    expect(dep1.isParallelTo(dep2.task)).toBe(false);
+
+    expect(prerequisitesOf(dep2)).toEqual(taskIds(dep0));
+    expect(dep2.isParallelTo(dep0.task)).toBe(true);
+    expect(dep2.isParallelTo(dep1.task)).toBe(false);
+  });
+
   it('calls sub-tasks in other packages', async () => {
 
     const target = testPlan.addPackage(

--- a/src/core/tasks/impl/group.task.spec.ts
+++ b/src/core/tasks/impl/group.task.spec.ts
@@ -9,7 +9,7 @@ describe('GroupZTask', () => {
     testPlan = new TestPlan();
   });
 
-  it('calls dependencies', async () => {
+  it('calls prerequisites', async () => {
     testPlan.addPackage(
         'test',
         {
@@ -77,7 +77,7 @@ describe('GroupZTask', () => {
     expect(dep3.params().attrs).toEqual({ attr1: ['on'], attr2: ['on'] });
   });
 
-  it('calls dependencies from other packages', async () => {
+  it('calls external prerequisites', async () => {
 
     const target = testPlan.addPackage(
         'test',

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -8,18 +8,18 @@ import { AbstractZTask } from './abstract.task';
  */
 export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
 
-  async *asDepOf(
+  async *asPre(
       dependent: ZCall,
-      dep: ZTaskSpec.TaskRef,
+      ref: ZTaskSpec.TaskRef,
   ): Iterable<ZCallInstruction> | AsyncIterable<ZCallInstruction> {
 
-    const { attrs, args } = dep;
+    const { attrs, args } = ref;
     const [subTaskName, ...subArgs] = args;
 
     if (subTaskName && !subTaskName.startsWith('-')) {
       // There is a sub-task to execute.
 
-      // Add task dependency. Pass call parameters to sub-task rather to this dependency.
+      // Add task prerequisite. Pass call parameters to sub-task rather to this prerequisite.
       yield {
         task: this,
         params: () => dependent.params(),
@@ -38,7 +38,7 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
         };
       }
     } else {
-      yield* super.asDepOf(dependent, dep);
+      yield* super.asPre(dependent, ref);
     }
   }
 
@@ -48,12 +48,12 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
 
   private _subTaskTargets(): ZPackageSet {
 
-    const { target, spec: { deps } } = this;
+    const { target, spec: { pre } } = this;
     let result: ZPackageSet | undefined;
 
-    for (let i = deps.length - 1; i >= 0; --i) {
+    for (let i = pre.length - 1; i >= 0; --i) {
 
-      const dep = deps[i];
+      const dep = pre[i];
 
       if (dep.selector) {
 

--- a/src/core/tasks/task-factory.spec.ts
+++ b/src/core/tasks/task-factory.spec.ts
@@ -17,7 +17,7 @@ describe('ZTaskFactory', () => {
         target,
         'test',
         {
-          deps: [],
+          pre: [],
           attrs: {},
           args: [],
           action: { type: 'wrong' } as any,

--- a/src/core/tasks/task-parser.spec.ts
+++ b/src/core/tasks/task-parser.spec.ts
@@ -34,11 +34,11 @@ describe('ZTaskParser', () => {
 
     expect(spec).toBe(ZTaskSpec.script);
   });
-  it('recognizes dependencies', () => {
+  it('recognizes prerequisites', () => {
 
     const spec = parser.parse('run-z dep1 dep2 dep3');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
         { task: 'dep1', parallel: false, attrs: {}, args: [] },
         { task: 'dep2', parallel: false, attrs: {}, args: [] },
         { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -50,7 +50,7 @@ describe('ZTaskParser', () => {
 
     const spec = parser.parse('run-z dep1 dep2 dep3 --some test');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -62,7 +62,7 @@ describe('ZTaskParser', () => {
 
     const spec = parser.parse('run-z dep1 dep2 dep3 --some --then cmd --arg');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -79,7 +79,7 @@ describe('ZTaskParser', () => {
 
     const spec = parser.parse('run-z dep1 dep2 dep3 --some --and cmd --arg');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -96,7 +96,7 @@ describe('ZTaskParser', () => {
 
     const spec = parser.parse('run-z dep1 dep2 dep3 --some --then');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -104,11 +104,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toEqual(['--some']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes dependency argument', () => {
+  it('recognizes prerequisite argument', () => {
 
     const spec = parser.parse('run-z dep1 dep2//-a //dep3 --some test');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a'] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -116,11 +116,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toEqual(['--some', 'test']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes shorthand dependency argument', () => {
+  it('recognizes shorthand prerequisite argument', () => {
 
     const spec = parser.parse('run-z dep1 dep2/-a dep3 --some test');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a'] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -128,11 +128,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toEqual(['--some', 'test']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes multiple dependency arguments', () => {
+  it('recognizes multiple prerequisite arguments', () => {
 
     const spec = parser.parse('run-z dep1 dep2//-a// //-b// //-c//dep3 --some test');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a', '-b', '-c'] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -140,11 +140,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toEqual(['--some', 'test']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes multiple shorthand dependency arguments', () => {
+  it('recognizes multiple shorthand prerequisite arguments', () => {
 
     const spec = parser.parse('run-z dep1 dep2/-a /-b //-c///-d dep3 --some test');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a', '-b', '-c', '-d'] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -152,11 +152,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toEqual(['--some', 'test']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('ignores empty dependency arguments', () => {
+  it('ignores empty prerequisite arguments', () => {
 
     const spec = parser.parse('run-z dep1 dep2 //// dep3 --some test');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -164,11 +164,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toEqual(['--some', 'test']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('ignores empty shorthand dependency arguments', () => {
+  it('ignores empty shorthand prerequisite arguments', () => {
 
     const spec = parser.parse('run-z dep1 dep2/ / dep3 --some test');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
       { task: 'dep3', parallel: false, attrs: {}, args: [] },
@@ -176,11 +176,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toEqual(['--some', 'test']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes parallel dependencies', () => {
+  it('recognizes parallel prerequisites', () => {
 
     const spec = parser.parse('run-z dep1,dep2, dep3 dep4');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: true, attrs: {}, args: [] },
       { task: 'dep3', parallel: true, attrs: {}, args: [] },
@@ -189,11 +189,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes parallel dependency arguments', () => {
+  it('recognizes parallel prerequisite arguments', () => {
 
     const spec = parser.parse('run-z dep1//-a//,dep2 //-b//, dep3');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: ['-a'] },
       { task: 'dep2', parallel: true, attrs: {}, args: ['-b'] },
       { task: 'dep3', parallel: true, attrs: {}, args: [] },
@@ -201,11 +201,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes parallel dependency shorthand arguments', () => {
+  it('recognizes parallel prerequisite shorthand arguments', () => {
 
     const spec = parser.parse('run-z dep1/-a/-b /-c,dep2 /-d, dep3');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: ['-a', '-b', '-c'] },
       { task: 'dep2', parallel: true, attrs: {}, args: ['-d'] },
       { task: 'dep3', parallel: true, attrs: {}, args: [] },
@@ -217,7 +217,7 @@ describe('ZTaskParser', () => {
 
     const spec = parser.parse('run-z dep1 ./path//selector dep2');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { selector: './path//selector' },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
@@ -225,11 +225,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes parallel external dependency', () => {
+  it('recognizes parallel external prerequisite', () => {
 
     const spec = parser.parse('run-z dep1, ./path//selector dep2');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { selector: './path//selector' },
       { task: 'dep2', parallel: true, attrs: {}, args: [] },
@@ -237,11 +237,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes parallel external dependency with standalone comma', () => {
+  it('recognizes parallel external prerequisite with standalone comma', () => {
 
     const spec = parser.parse('run-z dep1 ./path//selector , dep2');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { selector: './path//selector' },
       { task: 'dep2', parallel: true, attrs: {}, args: [] },
@@ -249,11 +249,11 @@ describe('ZTaskParser', () => {
     expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes parallel external dependency with comma prefix', () => {
+  it('recognizes parallel external prerequisite with comma prefix', () => {
 
     const spec = parser.parse('run-z dep1 ./path//selector ,dep2');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { selector: './path//selector' },
       { task: 'dep2', parallel: true, attrs: {}, args: [] },
@@ -272,11 +272,11 @@ describe('ZTaskParser', () => {
     });
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('recognizes dependency attributes', () => {
+  it('recognizes prerequisite attributes', () => {
 
     const spec = parser.parse('run-z attr1=val1 dep/attr2=/=attr3/arg1/--arg2=2/attr3=val3');
 
-    expect(spec.deps).toEqual([
+    expect(spec.pre).toEqual([
       {
         task: 'dep',
         parallel: false,
@@ -287,7 +287,7 @@ describe('ZTaskParser', () => {
     expect(spec.attrs).toEqual({ attr1: ['val1'] });
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
-  it('throws on arguments without dependency', () => {
+  it('throws on arguments without prerequisite', () => {
 
     let error!: InvalidZTaskError;
 
@@ -301,7 +301,7 @@ describe('ZTaskParser', () => {
     expect(error.commandLine).toBe('//-a// task');
     expect(error.position).toBe(0);
   });
-  it('throws on shorthand argument without dependency', () => {
+  it('throws on shorthand argument without prerequisite', () => {
 
     let error!: InvalidZTaskError;
 

--- a/src/core/tasks/task-parser.ts
+++ b/src/core/tasks/task-parser.ts
@@ -53,7 +53,7 @@ export class ZTaskParser {
     let e = 0;
     let entryIndex = 0;
     let entryPosition = 0;
-    const deps: ZTaskSpec.Dep[] = [];
+    const deps: ZTaskSpec.Pre[] = [];
     const attrs: Record<string, [string, ...string[]]> = {};
     let depTask: string | undefined;
     let depParallel = false;
@@ -195,7 +195,7 @@ export class ZTaskParser {
     }
 
     return {
-      deps,
+      pre: deps,
       attrs,
       args,
       action,

--- a/src/core/tasks/task-spec.ts
+++ b/src/core/tasks/task-spec.ts
@@ -9,11 +9,11 @@
 export interface ZTaskSpec<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> {
 
   /**
-   * Task dependencies.
+   * Task prerequisites.
    *
    * I.e. other tasks to run before this one.
    */
-  readonly deps: readonly ZTaskSpec.Dep[];
+  readonly pre: readonly ZTaskSpec.Pre[];
 
   /**
    * Task attributes.
@@ -35,16 +35,17 @@ export interface ZTaskSpec<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> 
 export namespace ZTaskSpec {
 
   /**
-   * Task dependency.
+   * Prerequisite of the  task.
    *
    * Either task or package reference.
    */
-  export type Dep = PackageRef | TaskRef;
+  export type Pre = PackageRef | TaskRef;
 
   /**
-   * Package reference.
+   * A reference to package of prerequisite tasks.
    *
-   * When present among {@link ZTaskSpec.deps task dependencies} the subsequent tasks are searched in selected packages.
+   * When present among {@link ZTaskSpec.pre task prerequisites} the subsequent tasks are searched in selected
+   * packages.
    */
   export interface PackageRef {
 
@@ -58,7 +59,7 @@ export namespace ZTaskSpec {
   }
 
   /**
-   * Task reference.
+   * Prerequisite task reference.
    */
   export interface TaskRef {
 
@@ -70,7 +71,7 @@ export namespace ZTaskSpec {
     readonly selector?: undefined;
 
     /**
-     * Whether this task can be executed in parallel with preceding one.
+     * Whether the referenced task can be executed in parallel with preceding one.
      */
     readonly parallel: boolean;
 
@@ -121,7 +122,7 @@ export namespace ZTaskSpec {
     readonly command: string;
 
     /**
-     * Whether the command can be executed in parallel with preceding dependency task.
+     * Whether the command can be executed in parallel with the last prerequisite.
      */
     readonly parallel: boolean;
 
@@ -178,7 +179,7 @@ const groupZTaskAction: ZTaskSpec.Group = {
  * @internal
  */
 const unknownZTaskSpec: ZTaskSpec<ZTaskSpec.Unknown> = {
-  deps: [],
+  pre: [],
   attrs: {},
   args: [],
   action: {
@@ -190,7 +191,7 @@ const unknownZTaskSpec: ZTaskSpec<ZTaskSpec.Unknown> = {
  * @internal
  */
 const scriptZTaskSpec: ZTaskSpec<ZTaskSpec.Script> = {
-  deps: [],
+  pre: [],
   attrs: {},
   args: [],
   action: {

--- a/src/core/tasks/task.ts
+++ b/src/core/tasks/task.ts
@@ -3,7 +3,7 @@
  * @module run-z
  */
 import type { ZPackage } from '../packages';
-import type { ZCall, ZCallInstruction, ZCallPlanner, ZTaskParams } from '../plan';
+import type { ZCall, ZCallPlanner, ZTaskParams } from '../plan';
 import type { ZTaskExecution } from '../plan/task-execution';
 import type { ZTaskSpec } from './task-spec';
 
@@ -51,18 +51,18 @@ export interface ZTask<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> {
   /**
    * Represents this task as a prerequisite of another one.
    *
-   * By default a {@link ZTaskSpec.Group grouping task} treats the first argument as a sub-task name, an the rest of
-   * arguments as arguments to this sub-task. The tasks of all other types record a call to this as is.
+   * By default a {@link ZTaskSpec.Group grouping task} treats the first argument as a sub-task name and the rest of
+   * arguments as arguments to this sub-task. A task of any other type returns a call to itself.
    *
-   * @param dependent  Depending task execution call.
+   * @param planner  Depending task planner.
    * @param ref  Prerequisite task reference.
    *
-   * @returns A potentially asynchronous iterable of {@link ZCallInstruction prerequisites call instructions}.
+   * @returns A promise resolved to iterable of prerequisite calls.
    */
   asPre(
-      dependent: ZCall,
+      planner: ZCallPlanner,
       ref: ZTaskSpec.TaskRef,
-  ): Iterable<ZCallInstruction> | AsyncIterable<ZCallInstruction>;
+  ): Promise<Iterable<ZCall>>;
 
   /**
    * Performs task execution.

--- a/src/core/tasks/task.ts
+++ b/src/core/tasks/task.ts
@@ -12,7 +12,7 @@ import type { ZTaskSpec } from './task-spec';
  *
  * @typeparam TAction  Task action type.
  */
-export interface ZTask<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> {
+export interface ZTask<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> extends ZTaskQualifier {
 
   /**
    * Target package the task is applied to.
@@ -73,5 +73,21 @@ export interface ZTask<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> {
    * executed asynchronously.
    */
   exec(execution: ZTaskExecution<TAction>): void | PromiseLike<unknown>;
+
+}
+
+/**
+ * Task qualifier.
+ *
+ * Any task may have multiple qualifiers.
+ *
+ * Qualifiers are distinguished by their identity.
+ */
+export interface ZTaskQualifier {
+
+  /**
+   * Human- readable task qualifier.
+   */
+  readonly taskQN: string;
 
 }

--- a/src/core/tasks/task.ts
+++ b/src/core/tasks/task.ts
@@ -49,19 +49,19 @@ export interface ZTask<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> {
   plan(planner: ZCallPlanner<TAction>): void | PromiseLike<unknown>;
 
   /**
-   * Represents this task as a dependency of another one.
+   * Represents this task as a prerequisite of another one.
    *
    * By default a {@link ZTaskSpec.Group grouping task} treats the first argument as a sub-task name, an the rest of
    * arguments as arguments to this sub-task. The tasks of all other types record a call to this as is.
    *
    * @param dependent  Depending task execution call.
-   * @param dep  Dependency specifier.
+   * @param ref  Prerequisite task reference.
    *
-   * @returns A potentially asynchronous iterable of {@link ZCallInstruction dependency call instructions}.
+   * @returns A potentially asynchronous iterable of {@link ZCallInstruction prerequisites call instructions}.
    */
-  asDepOf(
+  asPre(
       dependent: ZCall,
-      dep: ZTaskSpec.TaskRef,
+      ref: ZTaskSpec.TaskRef,
   ): Iterable<ZCallInstruction> | AsyncIterable<ZCallInstruction>;
 
   /**


### PR DESCRIPTION
- Rename task dependencies to prerequisites
- Introduce task qualifiers
- Do not set order or parallel execution between external prerequisites with the same task name