### PR TITLE
Unrecognized options

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@proc7ts/a-iterable": "^2.7.0",
     "@proc7ts/call-thru": "^4.0.0",
     "@proc7ts/primitives": "^1.0.3",
-    "@run-z/optionz": "^1.0.0-dev.1",
+    "@run-z/optionz": "^1.0.0-dev.2",
     "shell-quote": "^1.7.2"
   },
   "devDependencies": {

--- a/src/core/plan/call.impl.ts
+++ b/src/core/plan/call.impl.ts
@@ -118,7 +118,7 @@ export class ZCallRecord<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> im
     );
 
     // Evaluate parameters.
-    const result: ZTaskParams.Mutable = { attrs: {}, args: [], actionArgs: [] };
+    const result: ZTaskParams.Mutable = { attrs: {}, args: [] };
 
     ZTaskParams.update(result, this.task.params());
     for (const [, params] of allParams) {

--- a/src/core/plan/call.spec.ts
+++ b/src/core/plan/call.spec.ts
@@ -19,7 +19,6 @@ describe('ZCall', () => {
     initParams = {
       attrs: { attr1: ['attr1-val'] },
       args: ['arg1'],
-      actionArgs: ['cmd-arg1'],
     };
 
     task = setup.taskFactory
@@ -30,7 +29,7 @@ describe('ZCall', () => {
           type: 'command',
           command: 'test-command',
           parallel: false,
-          args: initParams.actionArgs,
+          args: ['cmd-arg1'],
         })
         .task();
   });
@@ -41,7 +40,7 @@ describe('ZCall', () => {
       const call = await plan({ attrs: { attr1: ['attr1-val2'] } });
 
       expect(call.params()).toEqual({
-        ...initParams,
+        args: ['cmd-arg1', 'arg1'],
         attrs: { ...initParams.attrs, attr1: ['attr1-val', 'attr1-val2'] },
       });
     });
@@ -50,7 +49,7 @@ describe('ZCall', () => {
       const call = await plan({ attrs: { attr2: ['attr2-val'] } });
 
       expect(call.params()).toEqual({
-        ...initParams,
+        args: ['cmd-arg1', 'arg1'],
         attrs: { ...initParams.attrs, attr2: ['attr2-val'] },
       });
     });
@@ -60,16 +59,7 @@ describe('ZCall', () => {
 
       expect(call.params()).toEqual({
         ...initParams,
-        args: [...initParams.args, 'arg2'],
-      });
-    });
-    it('appends action args', async () => {
-
-      const call = await plan({ actionArgs: ['cmd-arg2'] });
-
-      expect(call.params()).toEqual({
-        ...initParams,
-        actionArgs: [...initParams.actionArgs, 'cmd-arg2'],
+        args: ['cmd-arg1', 'arg1', 'arg2'],
       });
     });
   });
@@ -116,12 +106,10 @@ describe('ZCall', () => {
       expect(call.extendParams({
         attrs: { attr1: ['attr1-val2'] },
         args: ['arg2'],
-        actionArgs: ['cmd-arg2'],
       })()).toEqual({
         ...initParams,
         attrs: { ...initParams.attrs, attr1: ['attr1-val', 'attr1-val2'] },
-        args: [...initParams.args, 'arg2'],
-        actionArgs: [...initParams.actionArgs, 'cmd-arg2'],
+        args: ['cmd-arg1', 'arg1', 'arg2'],
       });
     });
   });

--- a/src/core/plan/task-params.spec.ts
+++ b/src/core/plan/task-params.spec.ts
@@ -9,12 +9,10 @@ describe('ZTaskParams', () => {
     initial = {
       attrs: { attr: ['val'] },
       args: ['arg1'],
-      actionArgs: ['cmd1'],
     };
     mutable = {
       attrs: {},
       args: [],
-      actionArgs: [],
     };
     ZTaskParams.update(mutable, initial);
   });
@@ -36,13 +34,6 @@ describe('ZTaskParams', () => {
       expect(mutable).toEqual({
         ...initial,
         args: ['arg1', 'arg2'],
-      });
-    });
-    it('appends action arguments', () => {
-      ZTaskParams.update(mutable, { actionArgs: ['cmd2'] });
-      expect(mutable).toEqual({
-        ...initial,
-        actionArgs: ['cmd1', 'cmd2'],
       });
     });
   });

--- a/src/core/plan/task-params.ts
+++ b/src/core/plan/task-params.ts
@@ -31,7 +31,7 @@ export class ZTaskParams {
       update: ZTaskParams.Partial,
   ): ZTaskParams.Mutable {
 
-    const { attrs = {}, args = [], actionArgs = [] } = update;
+    const { attrs = {}, args = [] } = update;
 
     for (const [k, v] of Object.entries(attrs)) {
       if (!v) {
@@ -47,7 +47,6 @@ export class ZTaskParams {
       }
     }
     params.args.push(...args);
-    params.actionArgs.push(...actionArgs);
 
     return params;
   }
@@ -63,21 +62,13 @@ export class ZTaskParams {
   readonly args: readonly string[];
 
   /**
-   * Command line arguments to pass to task action.
-   *
-   * E.g. {@link ZTaskSpec.Command.args command arguments}.
-   */
-  readonly actionArgs: readonly string[];
-
-  /**
    * Constructs task execution parameters.
    *
-   * @param init  Initial task execution parameter values.
+   * @param values  Task execution parameter values.
    */
-  constructor(init: ZTaskParams.Values) {
-    this.attrs = init.attrs;
-    this.args = init.args;
-    this.actionArgs = init.actionArgs;
+  constructor(values: ZTaskParams.Values) {
+    this.attrs = values.attrs;
+    this.args = values.args;
   }
 
   /**
@@ -116,7 +107,7 @@ export class ZTaskParams {
    */
   mutate(): ZTaskParams.Mutable {
 
-    const result: ZTaskParams.Mutable = { attrs: {}, args: [], actionArgs: [] };
+    const result: ZTaskParams.Mutable = { attrs: {}, args: [] };
 
     ZTaskParams.update(result, this);
 
@@ -158,13 +149,6 @@ export namespace ZTaskParams {
      */
     readonly args?: readonly string[];
 
-    /**
-     * Command line arguments to pass to task action.
-     *
-     * E.g. {@link ZTaskSpec.Command.args command arguments}.
-     */
-    readonly actionArgs?: readonly string[];
-
   }
 
   /**
@@ -181,11 +165,6 @@ export namespace ZTaskParams {
      * Command line arguments to pass to the task.
      */
     args: string[];
-
-    /**
-     * Command line arguments to pass to task action.
-     */
-    actionArgs: string[];
 
   }
 

--- a/src/core/tasks/impl/command.task.spec.ts
+++ b/src/core/tasks/impl/command.task.spec.ts
@@ -27,9 +27,8 @@ describe('CommandZTask', () => {
     const params = call.params();
 
     expect(call.task).toBeInstanceOf(CommandZTask);
-    expect(params.args).toHaveLength(0);
+    expect(params.args).toEqual(['--cmd']);
     expect(params.attrs).toEqual({ attr: ['b'] });
-    expect(params.actionArgs).toEqual(['--cmd']);
   });
 
   it('calls prerequisites', async () => {
@@ -148,8 +147,7 @@ describe('CommandZTask', () => {
 
       const params = shell.execCommand.mock.calls[0][1];
 
-      expect(params.args).toEqual(['--arg1', '--arg2']);
-      expect(params.actionArgs).toEqual(['--arg3']);
+      expect(params.args).toEqual(['--arg3', '--arg1', '--arg2']);
     });
   });
 });

--- a/src/core/tasks/impl/command.task.spec.ts
+++ b/src/core/tasks/impl/command.task.spec.ts
@@ -148,7 +148,7 @@ describe('CommandZTask', () => {
 
       const params = shell.execCommand.mock.calls[0][1];
 
-      expect(params.args).toEqual(['--arg2', '--arg1']);
+      expect(params.args).toEqual(['--arg1', '--arg2']);
       expect(params.actionArgs).toEqual(['--arg3']);
     });
   });

--- a/src/core/tasks/impl/command.task.spec.ts
+++ b/src/core/tasks/impl/command.task.spec.ts
@@ -17,7 +17,7 @@ describe('CommandZTask', () => {
         {
           packageJson: {
             scripts: {
-              test: 'run-z attr=b --arg --then exec --cmd',
+              test: 'run-z attr=b --then exec --cmd',
             },
           },
         },
@@ -27,7 +27,7 @@ describe('CommandZTask', () => {
     const params = call.params();
 
     expect(call.task).toBeInstanceOf(CommandZTask);
-    expect(params.args).toEqual(['--arg']);
+    expect(params.args).toHaveLength(0);
     expect(params.attrs).toEqual({ attr: ['b'] });
     expect(params.actionArgs).toEqual(['--cmd']);
   });

--- a/src/core/tasks/impl/command.task.ts
+++ b/src/core/tasks/impl/command.task.ts
@@ -10,9 +10,9 @@ export class CommandZTask extends AbstractZTask<ZTaskSpec.Command> {
 
   params(): ZTaskParams.Partial {
 
-    const { spec: { attrs, args, action: { args: actionArgs } } } = this;
+    const { spec: { attrs, args, action: { args: commandArgs } } } = this;
 
-    return { attrs, args, actionArgs };
+    return { attrs, args: [...commandArgs, ...args] };
   }
 
   exec(execution: ZTaskExecution<ZTaskSpec.Command>): Promise<void> {

--- a/src/core/tasks/impl/script.task.spec.ts
+++ b/src/core/tasks/impl/script.task.spec.ts
@@ -62,7 +62,7 @@ describe('ScriptZTask', () => {
 
       const params = shell.execScript.mock.calls[0][1];
 
-      expect(params.args).toEqual(['--arg2', '--arg1']);
+      expect(params.args).toEqual(['--arg1', '--arg2']);
     });
   });
 });

--- a/src/core/tasks/impl/script.task.spec.ts
+++ b/src/core/tasks/impl/script.task.spec.ts
@@ -31,7 +31,6 @@ describe('ScriptZTask', () => {
 
     expect(params.attrs).toEqual({});
     expect(params.args).toHaveLength(0);
-    expect(params.actionArgs).toHaveLength(0);
   });
 
   describe('exec', () => {

--- a/src/core/tasks/impl/task-builder.ts
+++ b/src/core/tasks/impl/task-builder.ts
@@ -21,6 +21,10 @@ export class ZTaskBuilder$<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> 
   constructor(readonly target: ZPackage, readonly name: string) {
   }
 
+  get action(): TAction | undefined {
+    return this._action as TAction;
+  }
+
   addPre(pre: ZTaskSpec.Pre): this {
     this._pre.push(pre);
     return this;

--- a/src/core/tasks/impl/task-spec-parser.ts
+++ b/src/core/tasks/impl/task-spec-parser.ts
@@ -194,10 +194,14 @@ function readNamedZTaskArg(option: ZTaskOption): void {
  * @internal
  */
 function readNameValueZTaskArg(option: ZTaskOption): void {
+
+  const [value] = option.values(1);
+  const arg = `${option.name}=${value}`;
+
   if (option.preTask) {
-    option.addPreArg(option.name, ...option.values());
+    option.addPreArg(arg);
   } else {
-    option.addArg(option.name, ...option.values());
+    option.addArg(arg);
   }
 }
 

--- a/src/core/tasks/task-builder.ts
+++ b/src/core/tasks/task-builder.ts
@@ -27,6 +27,11 @@ export interface ZTaskBuilder<TAction extends ZTaskSpec.Action = ZTaskSpec.Actio
   readonly name: string;
 
   /**
+   * Action specifier set by {@link setAction}.
+   */
+  readonly action?: TAction;
+
+  /**
    * Appends a task prerequisite.
    *
    * @param pre  Prerequisite specifier to append.

--- a/src/core/tasks/task-factory.spec.ts
+++ b/src/core/tasks/task-factory.spec.ts
@@ -1,5 +1,5 @@
 import { TestPlan } from '../../spec';
-import { UnknownZTask } from './impl';
+import { GroupZTask, UnknownZTask } from './impl';
 import { ZTaskSpec } from './task-spec';
 
 describe('ZTaskFactory', () => {
@@ -10,7 +10,15 @@ describe('ZTaskFactory', () => {
     testPlan = new TestPlan();
   });
 
-  it('constructs unknown task by default', async () => {
+  it('constructs grouping task by default', async () => {
+
+    const target = await testPlan.target();
+    const task = testPlan.setup.taskFactory.newTask(target, 'test').task();
+
+    expect(task.spec.action).toBe(ZTaskSpec.groupAction);
+    expect(task).toBeInstanceOf(GroupZTask);
+  });
+  it('constructs unknown task for illegal spec', async () => {
 
     const target = await testPlan.target();
     const task = testPlan.setup.taskFactory.newTask(target, 'test').setAction({ type: 'wrong' } as any).task();

--- a/src/core/tasks/task-option.ts
+++ b/src/core/tasks/task-option.ts
@@ -72,7 +72,9 @@ export interface ZTaskOption extends ZOption {
   addAttrs(attrs: ZTaskSpec.Attrs): void;
 
   /**
-   * Appends raw command line argument(s) to the task.
+   * Appends raw command line argument(s) to the task action.
+   *
+   * It is illegal to add arguments without {@link setAction action set}.
    *
    * @param args  Command line argument(s) to append.
    */

--- a/src/core/tasks/task-option.ts
+++ b/src/core/tasks/task-option.ts
@@ -24,6 +24,11 @@ export interface ZTaskOption extends ZOption {
   readonly taskName: string;
 
   /**
+   * The name of prerequisite added by the most recent call to {@link addPreTask}, unless it is already complete.
+   */
+  readonly preTask?: string;
+
+  /**
    * Appends a task prerequisite.
    *
    * @param pre  Prerequisite specifier to append.
@@ -31,18 +36,20 @@ export interface ZTaskOption extends ZOption {
   addPre(pre: ZTaskSpec.Pre): void;
 
   /**
-   * Appends a task prerequisite.
+   * Initiates a call to prerequisite task.
+   *
+   * The prerequisite will be added as soon as task specification modified by any method but {@link addPreArgs()}.
    *
    * @param name  Prerequisite task name to append.
    */
   addPreTask(name: string): void
 
   /**
-   * Appends arguments to prerequisite task added by the most recent call to {@link addPreTask}.
+   * Appends argument(s) to prerequisite task call initiated by the most recent call to {@link addPreTask}.
    *
    * @param args  Prerequisite arguments to add. May contain attributes.
    */
-  addPreArgs(...args: readonly string[]): void;
+  addPreArg(...args: string[]): void;
 
   /**
    * Makes a prerequisite added by the most recent call to {@link addPreTask} run in parallel with the next one.

--- a/src/core/tasks/task-parser.spec.ts
+++ b/src/core/tasks/task-parser.spec.ts
@@ -63,14 +63,15 @@ describe('ZTaskParser', () => {
   });
   it('recognizes arguments', async () => {
 
-    const spec = await parseSpec('run-z dep1 dep2 dep3 --some test');
+    const spec = await parseSpec('run-z --test=value dep1 dep2 dep3 --dep-arg1=value --dep-arg2 test');
 
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--dep-arg1', 'value', '--dep-arg2'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toEqual(['--test', 'value']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('recognizes command', async () => {
@@ -80,9 +81,9 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
     ]);
-    expect(spec.args).toEqual(['--some']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toEqual({
       type: 'command',
       command: 'cmd',
@@ -97,9 +98,9 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
     ]);
-    expect(spec.args).toEqual(['--some']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toEqual({
       type: 'command',
       command: 'cmd',
@@ -114,9 +115,9 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
     ]);
-    expect(spec.args).toEqual(['--some']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toEqual({
       type: 'command',
       command: 'cmd',
@@ -131,9 +132,9 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
     ]);
-    expect(spec.args).toEqual(['--some']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('recognizes prerequisite argument', async () => {
@@ -143,9 +144,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a'] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('recognizes shorthand prerequisite argument', async () => {
@@ -155,9 +157,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a'] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('recognizes multiple prerequisite arguments', async () => {
@@ -167,9 +170,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a', '-b', '-c'] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('recognizes prerequisite arguments with multi-slash delimiter', async () => {
@@ -179,9 +183,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a', '-b', '-c'] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('recognizes quoted prerequisite arguments', async () => {
@@ -191,9 +196,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a -b -c'] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('reads unclosed prerequisite arguments up to the end', async () => {
@@ -214,9 +220,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: ['-a', '-b', '-c', '-d'] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('ignores empty prerequisite arguments', async () => {
@@ -226,9 +233,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('ignores empty shorthand prerequisite arguments', async () => {
@@ -238,9 +246,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: [] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--some'] },
+      { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--some', 'test']);
+    expect(spec.args).toHaveLength(0);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('recognizes parallel prerequisites', async () => {

--- a/src/core/tasks/task-parser.spec.ts
+++ b/src/core/tasks/task-parser.spec.ts
@@ -74,10 +74,10 @@ describe('ZTaskParser', () => {
     expect(spec.pre).toEqual([
       { task: 'dep1', parallel: false, attrs: {}, args: [] },
       { task: 'dep2', parallel: false, attrs: {}, args: [] },
-      { task: 'dep3', parallel: false, attrs: {}, args: ['--dep-arg1', 'value', '--dep-arg2'] },
+      { task: 'dep3', parallel: false, attrs: {}, args: ['--dep-arg1=value', '--dep-arg2'] },
       { task: 'test', parallel: false, attrs: {}, args: [] },
     ]);
-    expect(spec.args).toEqual(['--test', 'value', '--other']);
+    expect(spec.args).toEqual(['--test=value', '--other']);
     expect(spec.action).toBe(ZTaskSpec.groupAction);
   });
   it('throws on unrecognized option', async () => {

--- a/src/os/system-shell.impl.ts
+++ b/src/os/system-shell.impl.ts
@@ -14,7 +14,7 @@ export class SystemZShell implements ZShell {
   }
 
   execCommand(command: string, params: ZTaskParams): Promise<void> {
-    return this._run(command, [...params.actionArgs, ...params.args]);
+    return this._run(command, params.args);
   }
 
   execScript(name: string, params: ZTaskParams): Promise<void> {
@@ -30,9 +30,7 @@ export class SystemZShell implements ZShell {
     if (!isYarn) {
       args.push('--');
     }
-    args.push(name);
-    args.push(...params.actionArgs);
-    args.push(...params.args);
+    args.push(name, ...params.args);
 
     return this._run(command, args);
   }


### PR DESCRIPTION
Pass unrecognized options to preceding prerequisite or to action when set.
Throw on unrecognized options otherwise.