### PR TITLE
Batch rules

### DIFF
--- a/src/core/batches/batch-details.spec.ts
+++ b/src/core/batches/batch-details.spec.ts
@@ -1,20 +1,21 @@
 import { ZBatchDetails } from './batch-details';
 import { ZBatcher } from './batcher';
+import { ZBatching } from './batching';
 
 describe('ZBatchDetails', () => {
   describe('by', () => {
-    it('removes undefined batcher', () => {
+    it('reconstructs undefined batcher', () => {
 
-      const full = ZBatchDetails.by({ batcher: undefined });
+      const full = ZBatchDetails.by();
 
-      expect(full).not.toHaveProperty('batcher');
+      expect(full.batching).toBeInstanceOf(ZBatching);
     });
     it('preserves specified batcher', () => {
 
-      const batcher = ZBatcher.batchTask;
-      const full = ZBatchDetails.by({ batcher });
+      const batching = new ZBatching(ZBatcher.batchTask);
+      const full = ZBatchDetails.by({ batching });
 
-      expect(full.batcher).toBe(batcher);
+      expect(full.batching).toBe(batching);
     });
   });
 });

--- a/src/core/batches/batch-details.ts
+++ b/src/core/batches/batch-details.ts
@@ -4,7 +4,7 @@
  */
 import { ZCallDetails } from '../plan';
 import type { ZTaskSpec } from '../tasks';
-import type { ZBatcher } from './batcher';
+import { ZBatching } from './batching';
 
 /**
  * Details of the {@link ZBatchPlanner.batch task batching}.
@@ -14,11 +14,11 @@ import type { ZBatcher } from './batcher';
 export interface ZBatchDetails<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> extends ZCallDetails<TAction> {
 
   /**
-   * The batcher to batch transient calls with.
+   * A policy to apply when batching transient calls.
    *
-   * @default Current batcher.
+   * @default Current batching policy.
    */
-  readonly batcher?: ZBatcher;
+  readonly batching?: ZBatching;
 
 }
 
@@ -32,11 +32,9 @@ export namespace ZBatchDetails {
   export interface Full<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> extends ZCallDetails.Full<TAction> {
 
     /**
-     * The batcher to batch transient calls with.
-     *
-     * @default Current batcher.
+     * A policy to apply when batching transient calls.
      */
-    readonly batcher?: ZBatcher;
+    readonly batching: ZBatching;
 
   }
 
@@ -53,14 +51,15 @@ export const ZBatchDetails = {
    * @returns Full task batching details.
    */
   by<TAction extends ZTaskSpec.Action>(
-      details?: ZBatchDetails<TAction>,
+      details: ZBatchDetails<TAction> = {},
   ): ZBatchDetails.Full<TAction> {
-    return details?.batcher
-        ? {
-          ...ZCallDetails.by(details),
-          batcher: details.batcher,
-        }
-        : ZCallDetails.by(details);
+
+    const { batching = new ZBatching() } = details;
+
+    return {
+      ...ZCallDetails.by(details),
+      batching,
+    };
   },
 
 };

--- a/src/core/batches/batch-planner.ts
+++ b/src/core/batches/batch-planner.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  * @module run-z
  */
-import type { ZPackage } from '../packages';
+import type { ZPackageSet } from '../packages';
 import type { ZCallPlanner } from '../plan';
 import type { ZTask, ZTaskSpec } from '../tasks';
 import type { ZBatchDetails } from './batch-details';
@@ -20,9 +20,9 @@ export interface ZBatchPlanner {
   readonly dependent: ZCallPlanner;
 
   /**
-   * Target package to apply batched tasks to.
+   * Target packages to batch the named tasks of.
    */
-  readonly target: ZPackage;
+  readonly targets: ZPackageSet;
 
   /**
    * Batched tasks name.

--- a/src/core/batches/batch-planner.ts
+++ b/src/core/batches/batch-planner.ts
@@ -3,7 +3,7 @@
  * @module run-z
  */
 import type { ZPackageSet } from '../packages';
-import type { ZCallPlanner } from '../plan';
+import type { ZCall, ZCallPlanner } from '../plan';
 import type { ZTask, ZTaskSpec } from '../tasks';
 import type { ZBatchDetails } from './batch-details';
 
@@ -42,6 +42,6 @@ export interface ZBatchPlanner {
       this: void,
       task: ZTask<TAction>,
       details?: ZBatchDetails<TAction>,
-  ): Promise<void>;
+  ): Promise<ZCall>;
 
 }

--- a/src/core/batches/batch-rule.ts
+++ b/src/core/batches/batch-rule.ts
@@ -1,0 +1,92 @@
+/**
+ * @packageDocumentation
+ * @module run-z
+ */
+import type { ZBatch } from './batch';
+import type { ZBatching } from './batching';
+
+/**
+ * Batch processing rule.
+ *
+ * When rule {@link ZBatching.rule applied} to batching policy, a rule control instance is created for it.
+ * Control instance interface contains methods updating batching policy.
+ *
+ * @typeparam TControl  A type of batch processing rule control.
+ */
+export interface ZBatchRule<TControl> {
+
+  /**
+   * Create batch processing rule instance.
+   *
+   * @param context  Batch processing rule context.
+   *
+   * @returns New batch processing rule instance.
+   */
+  newInstance(context: ZBatchRule.Context<TControl>): ZBatchRule.Instance<TControl>;
+
+}
+
+export namespace ZBatchRule {
+
+  /**
+   * Batch processing rule context.
+   *
+   * Rule instance can use is to update the rule processing policy.
+   *
+   * @typeparam TControl  A type of batch processing rule control.
+   */
+  export interface Context<TControl> {
+
+    /**
+     * Updates batch processing policy by replacing the rule processing instance with new one.
+     *
+     * @param update  A function accepting new processing rule context, and returning either new rule instance or
+     * nothing to remove the rule from new batch processing policy.
+     *
+     * @returns Updated batch processing policy.
+     */
+    updateInstance(
+        update: (this: void, context: Context<TControl>) => Instance<TControl> | null | undefined,
+    ): ZBatching;
+
+  }
+
+  /**
+   * Batch processing rule instance.
+   *
+   * Processes batched tasks in arbitrary way. E.g. by making them run in parallel.
+   *
+   * Instances {@link ZBatchRule.newInstance created} by rules. They should be {@link Context.updateInstance applied}
+   * to the policy in order to have effect.
+   *
+   * @typeparam TControl  A type of batch processing rule control.
+   */
+  export interface Instance<TControl> {
+
+    /**
+     * Batch processing rule control.
+     */
+    readonly control: TControl;
+
+    /**
+     * Applies this instance to another batch processing policy.
+     *
+     * @param context  Batch processing rule context bound to another processing policy instance.
+     *
+     * @returns Batch processing rule instance bound to new context.
+     */
+    moveTo(context: Context<TControl>): Instance<TControl>;
+
+    /**
+     * Processes the batch.
+     *
+     * @param batch  The batch to process.
+     *
+     * @returns Either nothing if batch processing completed synchronously, or a promise-like instance resolved when
+     * the batch processed asynchronously.
+     */
+    processBatch(batch: ZBatch): void | PromiseLike<unknown>;
+
+  }
+
+}

--- a/src/core/batches/batch-rule.ts
+++ b/src/core/batches/batch-rule.ts
@@ -72,10 +72,12 @@ export namespace ZBatchRule {
      * Applies this instance to another batch processing policy.
      *
      * @param context  Batch processing rule context bound to another processing policy instance.
+     * @param transiently  Whether to move to transient policy. E.g. to task prerequisites.
      *
-     * @returns Batch processing rule instance bound to new context.
+     * @returns Batch processing rule instance bound to new context, or `false` or nothing nothing if the instance
+     * is not applicable to new context.
      */
-    moveTo(context: Context<TControl>): Instance<TControl>;
+    moveTo(context: Context<TControl>, transiently: boolean): Instance<TControl> | false | null | undefined;
 
     /**
      * Processes the batch.

--- a/src/core/batches/batch.ts
+++ b/src/core/batches/batch.ts
@@ -2,11 +2,10 @@
  * @packageDocumentation
  * @module run-z
  */
-import type { ZCallPlanner } from '../plan';
-import type { ZTask } from '../tasks';
+import type { ZCall, ZCallPlanner } from '../plan';
 
 /**
- * A batch of tasks.
+ * A batch of task calls.
  */
 export interface ZBatch {
 
@@ -21,8 +20,8 @@ export interface ZBatch {
   readonly taskName: string;
 
   /**
-   * Batched tasks.
+   * Batched task calls.
    */
-  readonly batched: Iterable<ZTask>;
+  readonly batched: Iterable<ZCall>;
 
 }

--- a/src/core/batches/batch.ts
+++ b/src/core/batches/batch.ts
@@ -1,0 +1,28 @@
+/**
+ * @packageDocumentation
+ * @module run-z
+ */
+import type { ZCallPlanner } from '../plan';
+import type { ZTask } from '../tasks';
+
+/**
+ * A batch of tasks.
+ */
+export interface ZBatch {
+
+  /**
+   * A planner of the call to the task depending on the batched ones.
+   */
+  readonly dependent: ZCallPlanner;
+
+  /**
+   * The name of batched tasks.
+   */
+  readonly taskName: string;
+
+  /**
+   * Batched tasks.
+   */
+  readonly batched: Iterable<ZTask>;
+
+}

--- a/src/core/batches/batcher.impl.ts
+++ b/src/core/batches/batcher.impl.ts
@@ -1,0 +1,12 @@
+import { mapIt } from '@proc7ts/a-iterable';
+import type { ZBatchPlanner } from './batch-planner';
+
+/**
+ * @internal
+ */
+export async function batchZTask(this: void, planner: ZBatchPlanner): Promise<void> {
+  await Promise.all(mapIt(
+      await planner.targets.packages(),
+      target => target.task(planner.taskName).then(task => planner.batch(task)),
+  ));
+}

--- a/src/core/batches/batcher.spec.ts
+++ b/src/core/batches/batcher.spec.ts
@@ -1,7 +1,5 @@
-import { asis } from '@proc7ts/primitives';
 import { TestPlan } from '../../spec';
 import type { ZPackage, ZPackageTree } from '../packages';
-import type { ZCall } from '../plan';
 
 describe('ZBatcher', () => {
 
@@ -74,13 +72,12 @@ describe('ZBatcher', () => {
     });
 
     it('prefers matching task group', async () => {
+      await testPlan.parse('run-z --all other');
 
-      const call = await testPlan.parse('run-z --all other');
-
-      expect((await callOf(call, nested1, 'other')).params().attr('test')).toBe('other');
-      expect(await noCallOf(call, nested1, 'test')).toBeInstanceOf(TypeError);
-      expect(await noCallOf(call, nested2, 'other')).toBeInstanceOf(TypeError);
-      expect(await noCallOf(call, nested2, 'test')).toBeInstanceOf(TypeError);
+      expect((await testPlan.callOf(nested1, 'other')).params().attr('test')).toBe('other');
+      expect(await testPlan.noCallOf(nested1, 'test')).toBeInstanceOf(TypeError);
+      expect(await testPlan.noCallOf(nested2, 'other')).toBeInstanceOf(TypeError);
+      expect(await testPlan.noCallOf(nested2, 'test')).toBeInstanceOf(TypeError);
     });
 
     it('falls back to default batcher if no package sets defined', async () => {
@@ -102,21 +99,12 @@ describe('ZBatcher', () => {
     });
   });
 
-  async function callOf(call: ZCall, target: ZPackage, taskName: string): Promise<ZCall> {
-    return call.plan.callOf(await target.task(taskName));
-  }
-
-  function noCallOf(call: ZCall, target: ZPackage, taskName: string): Promise<any> {
-    return callOf(call, target, taskName).catch(asis);
-  }
-
   async function ensureTasksCalled(): Promise<void> {
+    await testPlan.parse('run-z --all test');
 
-    const call = await testPlan.parse('run-z --all test');
-
-    expect((await callOf(call, nested1, 'test')).params().attr('test')).toBe('main');
-    expect(await noCallOf(call, nested1, 'other')).toBeInstanceOf(TypeError);
-    expect((await callOf(call, nested2, 'test')).params().attr('test')).toBe('main');
-    expect(await noCallOf(call, nested2, 'other')).toBeInstanceOf(TypeError);
+    expect((await testPlan.callOf(nested1, 'test')).params().attr('test')).toBe('main');
+    expect(await testPlan.noCallOf(nested1, 'other')).toBeInstanceOf(TypeError);
+    expect((await testPlan.callOf(nested2, 'test')).params().attr('test')).toBe('main');
+    expect(await testPlan.noCallOf(nested2, 'other')).toBeInstanceOf(TypeError);
   }
 });

--- a/src/core/batches/batcher.ts
+++ b/src/core/batches/batcher.ts
@@ -4,6 +4,7 @@
  */
 import { itsEmpty, makeIt, mapIt } from '@proc7ts/a-iterable';
 import type { ZPackage } from '../packages';
+import type { ZCall } from '../plan';
 import type { ZTask, ZTaskSpec } from '../tasks';
 import { ZBatchDetails } from './batch-details';
 import type { ZBatchPlanner } from './batch-planner';
@@ -138,7 +139,7 @@ export const ZBatcher = {
         batch<TAction extends ZTaskSpec.Action>(
             task: ZTask<TAction>,
             details: ZBatchDetails<TAction>,
-        ): Promise<void> {
+        ): Promise<ZCall> {
           details = ZBatchDetails.by(details);
           return planner.batch(
               task,

--- a/src/core/batches/batching.ts
+++ b/src/core/batches/batching.ts
@@ -8,7 +8,8 @@ import type { ZBatch } from './batch';
 import type { ZBatchDetails } from './batch-details';
 import type { ZBatchPlanner } from './batch-planner';
 import type { ZBatchRule } from './batch-rule';
-import { ZBatcher } from './batcher';
+import type { ZBatcher } from './batcher';
+import { batchZTask } from './batcher.impl';
 
 /**
  * Task batching policy.
@@ -30,16 +31,13 @@ export class ZBatching {
   }
 
   /**
-   * Updates batcher to use.
+   * Updates a batcher to use.
    *
-   * @param batcher  Either new batcher or nothing.
+   * @param batcher  New batcher.
    *
-   * @returns New batcher policy, or `this` instance if new batcher is omitted.
+   * @returns New batcher policy using the given batcher.
    */
-  batchBy(batcher: ZBatcher | null | undefined): ZBatching {
-    if (!batcher) {
-      return this;
-    }
+  batchBy(batcher: ZBatcher): ZBatching {
 
     const newBatcher = new ZBatching(batcher);
 
@@ -68,14 +66,11 @@ export class ZBatching {
   /**
    * Merges batching policies.
    *
-   * @param other  Batching policy to merge with this one. Its setting have precedence over the ones of this policy.
+   * @param other  Batching policy to merge with this one. Its settings have precedence over the ones of this policy.
    *
-   * @returns Merged batching policy, or `this` one if batching policy to merge with is unspecified.
+   * @returns Merged batching policy.
    */
-  mergeWith(other: ZBatching | null | undefined): ZBatching {
-    if (!other) {
-      return this;
-    }
+  mergeWith(other: ZBatching): ZBatching {
 
     const { _batcher: newBatcher = this._batcher } = other;
     const newBatching = new ZBatching(newBatcher);
@@ -143,7 +138,7 @@ export class ZBatching {
       },
     };
 
-    await (this._batcher || ZBatcher.batchTask)(batchPlanner);
+    await (this._batcher || batchZTask)(batchPlanner);
 
     const batch: ZBatch = {
       dependent: planner.dependent,

--- a/src/core/batches/batching.ts
+++ b/src/core/batches/batching.ts
@@ -124,7 +124,7 @@ export class ZBatching {
    *
    * @returns A promise resolved when batch execution planned.
    */
-  async batch(planner: ZBatchPlanner): Promise<void> {
+  async batchAll(planner: ZBatchPlanner): Promise<void> {
 
     const batched: ZTask[] = [];
     const batchPlanner: ZBatchPlanner = {

--- a/src/core/batches/batching.ts
+++ b/src/core/batches/batching.ts
@@ -1,0 +1,151 @@
+/**
+ * @packageDocumentation
+ * @module run-z
+ */
+import type { ZTask, ZTaskSpec } from '../tasks';
+import type { ZBatch } from './batch';
+import type { ZBatchDetails } from './batch-details';
+import type { ZBatchPlanner } from './batch-planner';
+import type { ZBatchRule } from './batch-rule';
+import { ZBatcher } from './batcher';
+
+/**
+ * Task batching policy.
+ *
+ * This class instances are immutable.
+ */
+export class ZBatching {
+
+  private readonly _batcher?: ZBatcher;
+  private readonly _rules = new Map<ZBatchRule<unknown>, ZBatchRule.Instance<unknown>>();
+
+  /**
+   * Constructs task batching policy.
+   *
+   * @param batcher  Task batcher to use.
+   */
+  constructor(batcher?: ZBatcher) {
+    this._batcher = batcher;
+  }
+
+  /**
+   * Updates batcher to use.
+   *
+   * @param batcher  Either new batcher or nothing.
+   *
+   * @returns New batcher policy, or `this` instance if new batcher is omitted.
+   */
+  batchBy(batcher: ZBatcher | null | undefined): ZBatching {
+    if (!batcher) {
+      return this;
+    }
+
+    const newBatcher = new ZBatching(this._batcher);
+
+    newBatcher._by(this);
+
+    return newBatcher;
+  }
+
+  /**
+   * Retrieves control instance for batch processing rule.
+   *
+   * @typeparam TControl  A type of batch processing rule control.
+   * @param rule  Batch processing rule to retrieve control of.
+   *
+   * @returns A control instance for target batch processing rule.
+   */
+  rule<TControl>(rule: ZBatchRule<TControl>): TControl {
+
+    const instance = this._rules.get(rule);
+
+    return instance
+        ? instance.control as TControl
+        : rule.newInstance(this._ruleContext(rule)).control;
+  }
+
+  /**
+   * Merges batching policies.
+   *
+   * @param other  Batching policy to merge with this one. Its setting have precedence over the ones of this policy.
+   *
+   * @returns Merged batching policy.
+   */
+  mergeWith(other: ZBatching): ZBatching {
+
+    const { _batcher: newBatcher = this._batcher } = other;
+    const newBatching = new ZBatching(newBatcher);
+
+    newBatching._by(this);
+    newBatching._by(other);
+
+    return newBatching;
+  }
+
+  private _ruleContext<TControl>(rule: ZBatchRule<TControl>): ZBatchRule.Context<TControl> {
+
+    const oldBatching = this;
+
+    return {
+      updateInstance(update) {
+
+        const newBatching = new ZBatching(oldBatching._batcher);
+
+        newBatching._by(oldBatching, rule);
+
+        const newInstance = update(newBatching._ruleContext(rule));
+
+        if (newInstance) {
+          newBatching._rules.set(rule, newInstance);
+        }
+
+        return newBatching;
+      },
+    };
+  }
+
+  private _by(proto: ZBatching, exceptRule?: ZBatchRule<unknown>): void {
+    for (const [rule, ruleInstance] of proto._rules) {
+      if (rule !== exceptRule && !this._rules.has(rule)) {
+        this._rules.set(rule, ruleInstance.moveTo(this._ruleContext(rule)));
+      }
+    }
+  }
+
+  /**
+   * Performs batching.
+   *
+   * Records tasks to be executed in batch by {@link batchBy batcher} and applies {@link rule batching rules} to them.
+   *
+   * @param planner  Batch execution planner to record batched task calls to.
+   *
+   * @returns A promise resolved when batch execution planned.
+   */
+  async batch(planner: ZBatchPlanner): Promise<void> {
+
+    const batched: ZTask[] = [];
+    const batchPlanner: ZBatchPlanner = {
+      ...planner,
+      batch<TAction extends ZTaskSpec.Action>(
+          task: ZTask<TAction>,
+          details?: ZBatchDetails<TAction>,
+      ): Promise<void> {
+        batched.push(task);
+        return planner.batch(task, details);
+      },
+    };
+
+    await (this._batcher || ZBatcher.batchTask)(batchPlanner);
+
+    const batch: ZBatch = {
+      dependent: planner.dependent,
+      taskName: planner.taskName,
+      batched,
+    };
+
+    for (const ruleInstance of this._rules.values()) {
+      await ruleInstance.processBatch(batch);
+    }
+  }
+
+}

--- a/src/core/batches/batching.ts
+++ b/src/core/batches/batching.ts
@@ -69,9 +69,12 @@ export class ZBatching {
    *
    * @param other  Batching policy to merge with this one. Its setting have precedence over the ones of this policy.
    *
-   * @returns Merged batching policy.
+   * @returns Merged batching policy, or `this` one if batching policy to merge with is unspecified.
    */
-  mergeWith(other: ZBatching): ZBatching {
+  mergeWith(other: ZBatching | null | undefined): ZBatching {
+    if (!other) {
+      return this;
+    }
 
     const { _batcher: newBatcher = this._batcher } = other;
     const newBatching = new ZBatching(newBatcher);

--- a/src/core/batches/batching.ts
+++ b/src/core/batches/batching.ts
@@ -2,6 +2,7 @@
  * @packageDocumentation
  * @module run-z
  */
+import type { ZCall } from '../plan';
 import type { ZTask, ZTaskSpec } from '../tasks';
 import type { ZBatch } from './batch';
 import type { ZBatchDetails } from './batch-details';
@@ -126,15 +127,19 @@ export class ZBatching {
    */
   async batchAll(planner: ZBatchPlanner): Promise<void> {
 
-    const batched: ZTask[] = [];
+    const batched: ZCall[] = [];
     const batchPlanner: ZBatchPlanner = {
       ...planner,
-      batch<TAction extends ZTaskSpec.Action>(
+      async batch<TAction extends ZTaskSpec.Action>(
           task: ZTask<TAction>,
           details?: ZBatchDetails<TAction>,
-      ): Promise<void> {
-        batched.push(task);
-        return planner.batch(task, details);
+      ): Promise<ZCall> {
+
+        const call = await planner.batch(task, details);
+
+        batched.push(call);
+
+        return call;
       },
     };
 

--- a/src/core/batches/batching.ts
+++ b/src/core/batches/batching.ts
@@ -40,7 +40,7 @@ export class ZBatching {
       return this;
     }
 
-    const newBatcher = new ZBatching(this._batcher);
+    const newBatcher = new ZBatching(batcher);
 
     newBatcher._by(this);
 

--- a/src/core/batches/index.ts
+++ b/src/core/batches/index.ts
@@ -1,3 +1,6 @@
+export * from './batch';
 export * from './batch-details';
 export * from './batch-planner';
+export * from './batch-rule';
 export * from './batcher';
+export * from './batching';

--- a/src/core/batches/index.ts
+++ b/src/core/batches/index.ts
@@ -4,3 +4,4 @@ export * from './batch-planner';
 export * from './batch-rule';
 export * from './batcher';
 export * from './batching';
+export * from './rules';

--- a/src/core/batches/rules/index.ts
+++ b/src/core/batches/rules/index.ts
@@ -1,0 +1,1 @@
+export * from './parallel-batch.rule';

--- a/src/core/batches/rules/parallel-batch.rule.spec.ts
+++ b/src/core/batches/rules/parallel-batch.rule.spec.ts
@@ -1,0 +1,79 @@
+import { TestPlan } from '../../../spec';
+import type { ZPackage, ZPackageTree } from '../../packages';
+
+describe('ParallelZBatch', () => {
+
+  let testPlan: TestPlan;
+
+  beforeEach(() => {
+    testPlan = new TestPlan();
+  });
+
+  let main: ZPackageTree;
+  let nested1: ZPackage;
+  let nested2: ZPackage;
+
+  beforeEach(async () => {
+    main = testPlan.addPackage(
+        'main',
+        {
+          packageJson: {
+            scripts: {
+              'group/*': 'run-z test=main ./nested//',
+            },
+          },
+        },
+    );
+
+    testPlan.addPackage(
+        'main/nested/1',
+        {
+          packageJson: {
+            name: 'nested1',
+            scripts: {
+              test: 'exec nested1',
+            },
+          },
+        },
+    );
+    nested1 = await testPlan.target();
+
+    testPlan.addPackage(
+        'main/nested/2',
+        {
+          packageJson: {
+            name: 'nested2',
+            scripts: {
+              test: 'exec nested1',
+            },
+          },
+        },
+    );
+    nested2 = await testPlan.target();
+
+    await testPlan.target(main);
+  });
+
+  describe('--parallel-batch', () => {
+    it('executes tasks in parallel', async () => {
+      await testPlan.parse('run-z --all --parallel-batch test');
+
+      const call1 = await testPlan.callOf(nested1, 'test');
+      const call2 = await testPlan.callOf(nested2, 'test');
+
+      expect(call1.isParallelTo(call2.task)).toBe(true);
+    });
+  });
+
+  describe('--sequential-batch', () => {
+    it('executes tasks in parallel', async () => {
+      await testPlan.parse('run-z --all --sequential-batch test');
+
+      const call1 = await testPlan.callOf(nested1, 'test');
+      const call2 = await testPlan.callOf(nested2, 'test');
+
+      expect(call1.isParallelTo(call2.task)).toBe(false);
+    });
+  });
+
+});

--- a/src/core/batches/rules/parallel-batch.rule.ts
+++ b/src/core/batches/rules/parallel-batch.rule.ts
@@ -21,8 +21,8 @@ export class ParallelZBatch {
 
     return {
       control,
-      moveTo(context) {
-        return ParallelZBatch.newInstance(context, control.isParallel);
+      moveTo(context, transiently) {
+        return !transiently && ParallelZBatch.newInstance(context, control.isParallel);
       },
       processBatch({ dependent, batched }) {
         dependent.makeParallel(Array.from(batched, call => call.task));

--- a/src/core/batches/rules/parallel-batch.rule.ts
+++ b/src/core/batches/rules/parallel-batch.rule.ts
@@ -25,7 +25,7 @@ export class ParallelZBatch {
         return ParallelZBatch.newInstance(context, control.isParallel);
       },
       processBatch({ dependent, batched }) {
-        dependent.makeParallel(Array.from(batched));
+        dependent.makeParallel(Array.from(batched, call => call.task));
       },
     };
   }

--- a/src/core/batches/rules/parallel-batch.rule.ts
+++ b/src/core/batches/rules/parallel-batch.rule.ts
@@ -1,0 +1,58 @@
+/**
+ * @packageDocumentation
+ * @module run-z
+ */
+import type { ZBatchRule } from '../batch-rule';
+import type { ZBatching } from '../batching';
+
+/**
+ * Controller of parallel execution of batched rules.
+ *
+ * This class is a batch processing rule.
+ */
+export class ParallelZBatch {
+
+  static newInstance(
+      context: ZBatchRule.Context<ParallelZBatch>,
+      parallel = false,
+  ): ZBatchRule.Instance<ParallelZBatch> {
+
+    const control = new ParallelZBatch(context, parallel);
+
+    return {
+      control,
+      moveTo(context) {
+        return ParallelZBatch.newInstance(context, control.isParallel);
+      },
+      processBatch({ dependent, batched }) {
+        dependent.makeParallel(Array.from(batched));
+      },
+    };
+  }
+
+  private constructor(
+      private readonly _context: ZBatchRule.Context<ParallelZBatch>,
+      private readonly _parallel: boolean,
+  ) {
+  }
+
+  /**
+   * Whether batched rules will be executed parallel to each other.
+   */
+  get isParallel(): boolean {
+    return this._parallel;
+  }
+
+  /**
+   * Makes batched rules execute in parallel to each other.
+   *
+   * @param parallel  `true` or nothing to execute batched rules in parallel to each other, or `false` to execute them
+   * sequentially.
+   */
+  makeParallel(parallel = true): ZBatching {
+    return this._context.updateInstance(
+        context => parallel ? ParallelZBatch.newInstance(context, parallel) : undefined,
+    );
+  }
+
+}

--- a/src/core/plan/pre-planner.ts
+++ b/src/core/plan/pre-planner.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  * @module run-z
  */
-import type { ZBatcher } from '../batches';
+import type { ZBatching } from '../batches';
 import type { ZTask, ZTaskSpec } from '../tasks';
 import type { ZCall } from './call';
 import type { ZCallDetails } from './call-details';
@@ -21,9 +21,9 @@ export interface ZPrePlanner {
   readonly dependent: ZCallPlanner;
 
   /**
-   * Batcher to use to batch transient prerequisites.
+   * Batching policy to apply when batch transient prerequisites.
    */
-  readonly batcher: ZBatcher;
+  readonly batching: ZBatching;
 
   /**
    * Records a call to prerequisite task.
@@ -43,12 +43,12 @@ export interface ZPrePlanner {
   ): Promise<ZCall>;
 
   /**
-   * Builds a new prerequisites planner based on this one, but batching prerequisites with the given batcher.
+   * Builds a new prerequisites planner based on this one with updated batching policy for prerequisites.
    *
-   * @param batcher  New prerequisites batcher.
+   * @param batching  New prerequisites batching policy.
    *
-   * @returns Either new prerequisites planner, or this one if `batcher` is not specified.
+   * @returns Either new prerequisites planner, or this one if batching policy is unspecified.
    */
-  batchBy(batcher?: ZBatcher): ZPrePlanner;
+  batchWith(batching: ZBatching | null | undefined): ZPrePlanner;
 
 }

--- a/src/core/plan/pre-planner.ts
+++ b/src/core/plan/pre-planner.ts
@@ -47,8 +47,8 @@ export interface ZPrePlanner {
    *
    * @param batching  New prerequisites batching policy.
    *
-   * @returns Either new prerequisites planner, or this one if batching policy is unspecified.
+   * @returns New prerequisites planner.
    */
-  batchWith(batching: ZBatching | null | undefined): ZPrePlanner;
+  batchWith(batching: ZBatching): ZPrePlanner;
 
 }

--- a/src/core/plan/pre-planner.ts
+++ b/src/core/plan/pre-planner.ts
@@ -43,12 +43,12 @@ export interface ZPrePlanner {
   ): Promise<ZCall>;
 
   /**
-   * Builds a new prerequisites planner based on this one with updated batching policy for prerequisites.
+   * Builds a transient prerequisites planner based on this one with updated batching policy for prerequisites.
    *
-   * @param batching  New prerequisites batching policy.
+   * @param batching  Transient prerequisites batching policy.
    *
    * @returns New prerequisites planner.
    */
-  batchWith(batching: ZBatching): ZPrePlanner;
+  transient(batching: ZBatching): ZPrePlanner;
 
 }

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -77,7 +77,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
 
   protected async planPre(planner: ZCallPlanner<TAction>): Promise<void> {
 
-    const batching = this._builder._batching;
+    const batching = this._builder.batching;
     const { target, spec } = this;
     let parallel: ZTaskQualifier[] = [];
     let prevTasks: ZTask[] = [];

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -120,12 +120,12 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
         taskName: pre.task,
         batch(preTask, preDetails) {
 
-          const details = ZBatchDetails.by(preDetails);
+          const batchDetails = ZBatchDetails.by(preDetails);
 
           return preTask.callAsPre(
-              prePlanner.batchWith(details.batching),
+              prePlanner.batchWith(batchDetails.batching),
               pre,
-              details,
+              batchDetails,
           );
         },
       });

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -108,7 +108,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
           return preCall;
         },
         batchWith(newBatching) {
-          return { ...this, batching: batching.mergeWith(newBatching) };
+          return { ...this, batching: batching.mergeWithTransient(newBatching) };
         },
       };
 

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -30,11 +30,11 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
       planner: ZPrePlanner,
       { attrs, args }: ZTaskSpec.Pre,
       details: ZCallDetails.Full,
-  ): Promise<void> {
+  ): Promise<ZCall> {
 
     const taskParams = planner.dependent.plannedCall.extendParams({ attrs, args });
 
-    await planner.callPre(
+    return planner.callPre(
         this,
         {
           ...details,

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -107,7 +107,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
 
           return preCall;
         },
-        batchWith(newBatching) {
+        transient(newBatching) {
           return { ...this, batching: batching.mergeWithTransient(newBatching) };
         },
       };
@@ -123,7 +123,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
           const batchDetails = ZBatchDetails.by(preDetails);
 
           return preTask.callAsPre(
-              prePlanner.batchWith(batchDetails.batching),
+              prePlanner.transient(batchDetails.batching),
               pre,
               batchDetails,
           );

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -114,23 +114,21 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
 
       const preTargets = target.selectTargets(pre.targets);
 
-      for (const preTarget of await preTargets.packages()) {
-        await batching.batch({
-          dependent: planner,
-          target: preTarget,
-          taskName: pre.task,
-          batch(preTask, preDetails) {
+      await batching.batchAll({
+        dependent: planner,
+        targets: preTargets,
+        taskName: pre.task,
+        batch(preTask, preDetails) {
 
-            const details = ZBatchDetails.by(preDetails);
+          const details = ZBatchDetails.by(preDetails);
 
-            return preTask.callAsPre(
-                prePlanner.batchWith(details.batching),
-                pre,
-                details,
-            );
-          },
-        });
-      }
+          return preTask.callAsPre(
+              prePlanner.batchWith(details.batching),
+              pre,
+              details,
+          );
+        },
+      });
 
       if (calledTasks.length === 1) {
         parallel.push(calledTasks[0]);

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -17,7 +17,7 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
   readonly taskQN: string;
   readonly callDetails: ZCallDetails.Full<TAction>;
 
-  constructor(private readonly _builder: ZTaskBuilder$, readonly spec: ZTaskSpec<TAction>) {
+  constructor(protected readonly _builder: ZTaskBuilder$, readonly spec: ZTaskSpec<TAction>) {
     this.target = _builder.taskTarget;
     this.taskQN = this.name = _builder.taskName;
     this.callDetails = {

--- a/src/core/tasks/impl/group.task.spec.ts
+++ b/src/core/tasks/impl/group.task.spec.ts
@@ -1,4 +1,4 @@
-import { prerequisitesOf, taskIds, TestPlan } from '../../../spec';
+import { prerequisitesOf, taskId, taskIds, TestPlan } from '../../../spec';
 import { GroupZTask } from './group.task';
 
 describe('GroupZTask', () => {
@@ -307,7 +307,10 @@ describe('GroupZTask', () => {
     const dep2 = plan.callOf(await nested2.task('dep'));
     const sub2 = plan.callOf(await nested2.task('sub-task'));
 
-    expect(prerequisitesOf(call)).toEqual(taskIds(sub1, sub2));
+    const callPre = prerequisitesOf(call);
+
+    expect(callPre).toContainEqual(taskId(sub1));
+    expect(callPre).toContainEqual(taskId(sub2));
     expect(call.params().attrs).toEqual({ attr1: ['on'] });
 
     expect(prerequisitesOf(dep1)).toHaveLength(0);

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -45,13 +45,13 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
         },
     );
 
-    const { batcher } = planner;
+    const { batching } = planner;
 
     // Delegate to sub-task(s).
     const subTaskPre: ZTaskSpec.Pre = { ...pre, args: subArgs };
 
     for (const subTarget of await this._subTaskTargets().packages()) {
-      await batcher({
+      await batching.batch({
         dependent: planner.dependent,
         target: subTarget,
         taskName: subTaskName,
@@ -60,10 +60,10 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
             subDetails: ZBatchDetails<TAction> = {},
         ): Promise<void> => {
 
-          const { params, plan, batcher } = ZBatchDetails.by(subDetails);
+          const { params, plan, batching } = ZBatchDetails.by(subDetails);
 
           return subTask.callAsPre<TAction>(
-              planner.batchBy(batcher),
+              planner.batchWith(batching),
               subTaskPre,
               {
                 params: () => groupCall.params().extend(params()),

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -3,7 +3,7 @@ import { ZBatchDetails } from '../../batches';
 import type { ZExecutedProcess } from '../../jobs';
 import { noopZExecutedProcess } from '../../jobs/impl';
 import type { ZPackageSet } from '../../packages';
-import type { ZCallDetails, ZPrePlanner } from '../../plan';
+import type { ZCall, ZCallDetails, ZPrePlanner } from '../../plan';
 import type { ZTask } from '../task';
 import type { ZTaskSpec } from '../task-spec';
 import { AbstractZTask } from './abstract.task';
@@ -13,7 +13,7 @@ import { AbstractZTask } from './abstract.task';
  */
 export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
 
-  async callAsPre(planner: ZPrePlanner, pre: ZTaskSpec.Pre, details: ZCallDetails.Full): Promise<void> {
+  async callAsPre(planner: ZPrePlanner, pre: ZTaskSpec.Pre, details: ZCallDetails.Full): Promise<ZCall> {
 
     const { dependent } = planner;
     let subTaskName: string;
@@ -54,7 +54,7 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
       batch: <TAction extends ZTaskSpec.Action>(
           subTask: ZTask<TAction>,
           subDetails: ZBatchDetails<TAction> = {},
-      ): Promise<void> => {
+      ): Promise<ZCall> => {
 
         const { params, plan, batching } = ZBatchDetails.by(subDetails);
 
@@ -75,6 +75,8 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
         );
       },
     });
+
+    return groupCall;
   }
 
   exec(): ZExecutedProcess {

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -59,7 +59,7 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
         const { params, plan, batching } = ZBatchDetails.by(subDetails);
 
         return subTask.callAsPre<TAction>(
-            planner.batchWith(batching),
+            planner.transient(batching),
             { ...pre, args: subArgs, task: subTask.name },
             {
               params: () => groupCall.params().extend(params()),

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -45,11 +45,9 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
         },
     );
 
-    const { batching } = planner;
+    const batching = this._builder.batching.mergeWith(planner.batching);
 
     // Delegate to sub-task(s).
-    const subTaskPre: ZTaskSpec.Pre = { ...pre, args: subArgs };
-
     for (const subTarget of await this._subTaskTargets().packages()) {
       await batching.batch({
         dependent: planner.dependent,
@@ -64,7 +62,7 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
 
           return subTask.callAsPre<TAction>(
               planner.batchWith(batching),
-              subTaskPre,
+              { ...pre, args: subArgs, task: subTask.name },
               {
                 params: () => groupCall.params().extend(params()),
                 plan: async subPlanner => {

--- a/src/core/tasks/impl/parser/task-spec-option-class.ts
+++ b/src/core/tasks/impl/parser/task-spec-option-class.ts
@@ -1,6 +1,6 @@
 import type { ZOption } from '@run-z/optionz';
 import { ZOptionError } from '@run-z/optionz';
-import type { ZBatcher } from '../../../batches';
+import type { ZBatching } from '../../../batches';
 import type { ZPackage } from '../../../packages';
 import type { ZTaskOption } from '../../task-option';
 import type { ZTaskSpec } from '../../task-spec';
@@ -59,8 +59,8 @@ export function zTaskSpecOptionClass<TArgs extends any[]>(
       return this;
     }
 
-    setBatcher(batcher: ZBatcher): this {
-      this._draft.builder.setBatcher(batcher);
+    setBatching(batching: ZBatching): this {
+      this._draft.builder.setBatching(batching);
       return this;
     }
 

--- a/src/core/tasks/impl/parser/task-spec-option-class.ts
+++ b/src/core/tasks/impl/parser/task-spec-option-class.ts
@@ -25,6 +25,10 @@ export function zTaskSpecOptionClass<TArgs extends any[]>(
       _draft.moveTo(this);
     }
 
+    get batching(): ZBatching {
+      return this._draft.builder.batching;
+    }
+
     get pre(): ZTaskOption.Pre {
       return this._draft.pre;
     }

--- a/src/core/tasks/impl/parser/task-spec-options.ts
+++ b/src/core/tasks/impl/parser/task-spec-options.ts
@@ -1,6 +1,6 @@
 import { arrayOfElements, valueByRecipe } from '@proc7ts/primitives';
 import type { SupportedZOptions } from '@run-z/optionz';
-import { ZBatcher } from '../../../batches';
+import { ParallelZBatch, ZBatcher } from '../../../batches';
 import type { ZTaskOption } from '../../task-option';
 import type { ZTaskParser } from '../../task-parser';
 import type { DraftZTask } from './draft-task';
@@ -17,6 +17,11 @@ const defaultZTaskSpecOptions: SupportedZOptions.Map<ZTaskOption> = {
     option.setBatching(option.batching.batchBy(ZBatcher.topmost()));
     option.values(0);
   },
+
+  '--parallel-batch': readParallelZBatch.bind(undefined, true),
+  '--pbatch': readParallelZBatch.bind(undefined, true),
+  '--sequential-batch': readParallelZBatch.bind(undefined, false),
+  '--sbatch': readParallelZBatch.bind(undefined, false),
 
   '--*=*': readNameValueZTaskArg,
   '-*=*': readNameValueZTaskArg,
@@ -81,6 +86,14 @@ export function zTaskSpecOptions(
       .map(o => ({ builder }) => valueByRecipe(o, builder));
 
   return [defaultZTaskSpecOptions, ...providers];
+}
+
+/**
+ * @internal
+ */
+function readParallelZBatch(parallel: boolean, option: ZTaskOption): void {
+  option.setBatching(option.batching.rule(ParallelZBatch).makeParallel(parallel));
+  option.values(0);
 }
 
 /**

--- a/src/core/tasks/impl/parser/task-spec-options.ts
+++ b/src/core/tasks/impl/parser/task-spec-options.ts
@@ -1,6 +1,6 @@
 import { arrayOfElements, valueByRecipe } from '@proc7ts/primitives';
 import type { SupportedZOptions } from '@run-z/optionz';
-import { ZBatcher } from '../../../batches';
+import { ZBatcher, ZBatching } from '../../../batches';
 import type { ZTaskOption } from '../../task-option';
 import type { ZTaskParser } from '../../task-parser';
 import type { DraftZTask } from './draft-task';
@@ -14,7 +14,7 @@ const defaultZTaskSpecOptions: SupportedZOptions.Map<ZTaskOption> = {
   '--then': readZTaskCommand.bind(undefined, false),
 
   '--all'(option) {
-    option.setBatcher(ZBatcher.topmost());
+    option.setBatching(new ZBatching(ZBatcher.topmost()));
     option.values(0);
   },
 

--- a/src/core/tasks/impl/parser/task-spec-options.ts
+++ b/src/core/tasks/impl/parser/task-spec-options.ts
@@ -1,6 +1,6 @@
 import { arrayOfElements, valueByRecipe } from '@proc7ts/primitives';
 import type { SupportedZOptions } from '@run-z/optionz';
-import { ZBatcher, ZBatching } from '../../../batches';
+import { ZBatcher } from '../../../batches';
 import type { ZTaskOption } from '../../task-option';
 import type { ZTaskParser } from '../../task-parser';
 import type { DraftZTask } from './draft-task';
@@ -14,7 +14,7 @@ const defaultZTaskSpecOptions: SupportedZOptions.Map<ZTaskOption> = {
   '--then': readZTaskCommand.bind(undefined, false),
 
   '--all'(option) {
-    option.setBatching(new ZBatching(ZBatcher.topmost()));
+    option.setBatching(option.batching.batchBy(ZBatcher.topmost()));
     option.values(0);
   },
 

--- a/src/core/tasks/task-builder.impl.ts
+++ b/src/core/tasks/task-builder.impl.ts
@@ -1,4 +1,4 @@
-import { ZBatcher } from '../batches';
+import { ZBatching } from '../batches';
 import type { ZPackage } from '../packages';
 import type { AbstractZTask } from './impl';
 import { CommandZTask, GroupZTask, ScriptZTask, UnknownZTask } from './impl';
@@ -11,7 +11,7 @@ import { addZTaskAttr, addZTaskAttrs } from './task-spec.impl';
  */
 export class ZTaskBuilder$<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> implements ZTaskBuilder<TAction> {
 
-  _batcher: ZBatcher = ZBatcher.batchTask;
+  _batching: ZBatching = new ZBatching();
   private readonly _pre: ZTaskSpec.Pre[] = [];
   private readonly _attrs: Record<string, [string, ...string[]]> = {};
   private readonly _args: string[] = [];
@@ -44,8 +44,8 @@ export class ZTaskBuilder$<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> 
     return this;
   }
 
-  setBatcher(batcher: ZBatcher): this {
-    this._batcher = batcher;
+  setBatching(batching: ZBatching): this {
+    this._batching = batching;
     return this;
   }
 

--- a/src/core/tasks/task-builder.impl.ts
+++ b/src/core/tasks/task-builder.impl.ts
@@ -11,7 +11,7 @@ import { addZTaskAttr, addZTaskAttrs } from './task-spec.impl';
  */
 export class ZTaskBuilder$<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> implements ZTaskBuilder<TAction> {
 
-  _batching: ZBatching = new ZBatching();
+  batching: ZBatching = new ZBatching();
   private readonly _pre: ZTaskSpec.Pre[] = [];
   private readonly _attrs: Record<string, [string, ...string[]]> = {};
   private readonly _args: string[] = [];
@@ -45,7 +45,7 @@ export class ZTaskBuilder$<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> 
   }
 
   setBatching(batching: ZBatching): this {
-    this._batching = batching;
+    this.batching = batching;
     return this;
   }
 

--- a/src/core/tasks/task-modifier.ts
+++ b/src/core/tasks/task-modifier.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  * @module run-z
  */
-import type { ZBatcher } from '../batches';
+import type { ZBatching } from '../batches';
 import type { ZPackage } from '../packages';
 import type { ZTaskSpec } from './task-spec';
 
@@ -66,18 +66,18 @@ export interface ZTaskModifier {
   addArg(...args: string[]): this;
 
   /**
-   * Sets a batcher of prerequisite tasks to execute.
+   * Sets a policy for prerequisites batching.
    *
-   * Each prerequisite task name represents a batch of tasks to execute. The batch execution will be planned by the
-   * given `batcher`.
+   * Each prerequisite task name represents a batch of tasks to execute. The batch execution will be planned with the
+   * given `batching` policy.
    *
    * A single task call will be planned {@link ZBatcher.batchTask by default}.
    *
-   * @param batcher  New batcher.
+   * @param batching  New batching policy.
    *
    * @returns `this` instance.
    */
-  setBatcher(batcher: ZBatcher): this;
+  setBatching(batching: ZBatching): this;
 
   /**
    * Assigns a task action.

--- a/src/core/tasks/task-modifier.ts
+++ b/src/core/tasks/task-modifier.ts
@@ -24,6 +24,11 @@ export interface ZTaskModifier {
   readonly taskName: string;
 
   /**
+   * Prerequisites batching policy.
+   */
+  readonly batching: ZBatching;
+
+  /**
    * Action specifier set by {@link setAction}.
    */
   readonly action?: ZTaskSpec.Action;

--- a/src/core/tasks/task.ts
+++ b/src/core/tasks/task.ts
@@ -45,13 +45,13 @@ export interface ZTask<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> exte
    * @param ref  Prerequisite specifier.
    * @param details  Task call details.
    *
-   * @returns A promise resolved when prerequisite call planning completes.
+   * @returns A promise resolved to recorded prerequisite call.
    */
   callAsPre<TAction extends ZTaskSpec.Action>(
       planner: ZPrePlanner,
       ref: ZTaskSpec.Pre,
       details: ZCallDetails.Full<TAction>,
-  ): Promise<void>;
+  ): Promise<ZCall>;
 
   /**
    * Plans this task execution as a top-level task.

--- a/src/spec/test-plan.ts
+++ b/src/spec/test-plan.ts
@@ -13,14 +13,16 @@ export class TestPlan {
   constructor(
       name = 'root',
       {
+        setup = new ZSetup(),
         packageJson = {},
         shell,
       }: {
+        setup?: ZSetup;
         packageJson?: ZPackageJson;
         shell?: ZShell;
       } = {},
   ) {
-    this.setup = new ZSetup();
+    this.setup = setup;
     this._target = this.root = new ZPackageTree(name, { packageJson, shell });
   }
 


### PR DESCRIPTION
- Introduce `Batching` representing bathing policy
- Introduce batching rules processing batched task calls.
- Add `--sequential-batch` and `--parallel-batch` options utilizing `ParallelZBatch` rule