### PR TITLE
Named batch selectors

### DIFF
--- a/src/builtins/dep-graph/dep-graph-batches.spec.ts
+++ b/src/builtins/dep-graph/dep-graph-batches.spec.ts
@@ -26,12 +26,12 @@ describe('ZDepGraphBatches', () => {
       const test2 = await testPlan.callOf(nested2, 'test');
       const test3 = await testPlan.callOf(nested3, 'test');
 
-      expect(call.hasPrerequisite(all.task)).toBe(true);
+      expect(call.hasPrerequisite(all.task)).toBe(false);
       expect(call.hasPrerequisite(test1.task)).toBe(true);
       expect(call.hasPrerequisite(test2.task)).toBe(true);
       expect(call.hasPrerequisite(test3.task)).toBe(true);
 
-      expect(test2.hasPrerequisite(all.task)).toBe(true);
+      expect(test2.hasPrerequisite(all.task)).toBe(false);
       expect(test2.hasPrerequisite(test1.task)).toBe(true);
       expect(test3.hasPrerequisite(test2.task)).toBe(true);
 

--- a/src/core/tasks/impl/group.task.spec.ts
+++ b/src/core/tasks/impl/group.task.spec.ts
@@ -648,6 +648,140 @@ describe('GroupZTask', () => {
     expect(dep22.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr2: ['on'], test: ['on'], dep: ['2.2'] });
   });
 
+  it('reuses per-task selector', async () => {
+
+    const target = testPlan.addPackage(
+        'test',
+        {
+          packageJson: {
+            scripts: {
+              test: 'run-z ...reusable dep2/=attr2 =test',
+              reusable: 'run-z ./nested// dep1/=attr1',
+              'reusable/dep2': 'run-z ./nested// dep1/=attr3',
+            },
+          },
+        },
+    );
+
+    testPlan.addPackage(
+        'test/nested/nested1',
+        {
+          packageJson: {
+            scripts: {
+              dep1: 'run-z dep=1.1 --then exec11',
+              dep2: 'run-z dep=1.2 --then exec12',
+            },
+          },
+        },
+    );
+
+    const nested1 = await testPlan.target();
+
+    testPlan.addPackage(
+        'test/nested/nested2',
+        {
+          packageJson: {
+            scripts: {
+              dep1: 'run-z dep=2.1 --then exec21',
+              dep2: 'run-z dep=2.2 --then exec22',
+            },
+          },
+        },
+    );
+
+    const nested2 = await testPlan.target();
+
+    await testPlan.target(target);
+
+    const call = await testPlan.call('test');
+    const dep11 = await testPlan.callOf(nested1, 'dep1');
+    const dep12 = await testPlan.callOf(nested1, 'dep2');
+    const dep21 = await testPlan.callOf(nested2, 'dep1');
+    const dep22 = await testPlan.callOf(nested2, 'dep2');
+
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep12, dep22));
+    expect(call.params(ZTaskParams.newEvaluator()).attrs).toEqual({ test: ['on'] });
+
+    expect(prerequisitesOf(dep11)).toHaveLength(0);
+    expect(dep11.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr3: ['on'], test: ['on'], dep: ['1.1'] });
+
+    expect(prerequisitesOf(dep12)).toHaveLength(0);
+    expect(dep12.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr2: ['on'], test: ['on'], dep: ['1.2'] });
+
+    expect(prerequisitesOf(dep21)).toHaveLength(0);
+    expect(dep21.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr3: ['on'], test: ['on'], dep: ['2.1'] });
+
+    expect(prerequisitesOf(dep22)).toHaveLength(0);
+    expect(dep22.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr2: ['on'], test: ['on'], dep: ['2.2'] });
+  });
+
+  it('reuses universal selector', async () => {
+
+    const target = testPlan.addPackage(
+        'test',
+        {
+          packageJson: {
+            scripts: {
+              test: 'run-z ...reusable dep2/=attr2 =test',
+              reusable: 'run-z ./nested// dep1/=attr1',
+              'reusable/*': 'run-z ./nested// dep1/=attr3',
+            },
+          },
+        },
+    );
+
+    testPlan.addPackage(
+        'test/nested/nested1',
+        {
+          packageJson: {
+            scripts: {
+              dep1: 'run-z dep=1.1 --then exec11',
+              dep2: 'run-z dep=1.2 --then exec12',
+            },
+          },
+        },
+    );
+
+    const nested1 = await testPlan.target();
+
+    testPlan.addPackage(
+        'test/nested/nested2',
+        {
+          packageJson: {
+            scripts: {
+              dep1: 'run-z dep=2.1 --then exec21',
+              dep2: 'run-z dep=2.2 --then exec22',
+            },
+          },
+        },
+    );
+
+    const nested2 = await testPlan.target();
+
+    await testPlan.target(target);
+
+    const call = await testPlan.call('test');
+    const dep11 = await testPlan.callOf(nested1, 'dep1');
+    const dep12 = await testPlan.callOf(nested1, 'dep2');
+    const dep21 = await testPlan.callOf(nested2, 'dep1');
+    const dep22 = await testPlan.callOf(nested2, 'dep2');
+
+    expect(prerequisitesOf(call)).toEqual(taskIds(dep12, dep22));
+    expect(call.params(ZTaskParams.newEvaluator()).attrs).toEqual({ test: ['on'] });
+
+    expect(prerequisitesOf(dep11)).toHaveLength(0);
+    expect(dep11.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr3: ['on'], test: ['on'], dep: ['1.1'] });
+
+    expect(prerequisitesOf(dep12)).toHaveLength(0);
+    expect(dep12.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr2: ['on'], test: ['on'], dep: ['1.2'] });
+
+    expect(prerequisitesOf(dep21)).toHaveLength(0);
+    expect(dep21.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr3: ['on'], test: ['on'], dep: ['2.1'] });
+
+    expect(prerequisitesOf(dep22)).toHaveLength(0);
+    expect(dep22.params(ZTaskParams.newEvaluator()).attrs).toEqual({ attr2: ['on'], test: ['on'], dep: ['2.2'] });
+  });
+
   it('fails to reuse selector from non-group task', async () => {
     testPlan.addPackage(
         'test',

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -17,39 +17,30 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
   async callAsPre(planner: ZPrePlanner, pre: ZTaskSpec.Pre, details: ZCallDetails.Full): Promise<ZCall> {
 
     const { dependent } = planner;
-    let subTaskName: string;
-    let subArgs: readonly string[];
 
-    if (this.name === pre.task) {
-      // Task name is the same as prerequisite one.
-      // First argument contains the name of sub-task to call.
-      [subTaskName, ...subArgs] = pre.args;
-      if (!subTaskName || !ZOptionInput.isOptionValue(subTaskName)) {
-        // No sub-task name.
+    // First argument contains the name of sub-task to call.
+    const [subTaskName, ...subArgs] = pre.args;
 
-        // Report targets.
-        await this._planTargets(
-            this.spec.action.targets,
-            pre.task,
-            {
-              ...planner,
-              callPre<TAction extends ZTaskSpec.Action>(
-                  task: ZTask<TAction>,
-                  details?: ZCallDetails<TAction>,
-              ): Promise<ZCall> {
-                return planner.dependent.call(task, details);
-              },
+    if (!subTaskName || !ZOptionInput.isOptionValue(subTaskName)) {
+      // No sub-task name.
+
+      // Report targets.
+      await this._planTargets(
+          this.spec.action.targets,
+          pre.task,
+          {
+            ...planner,
+            callPre<TAction extends ZTaskSpec.Action>(
+                task: ZTask<TAction>,
+                details?: ZCallDetails<TAction>,
+            ): Promise<ZCall> {
+              return planner.dependent.call(task, details);
             },
-        );
+          },
+      );
 
-        // Fallback to default implementation.
-        return super.callAsPre(planner, pre, details);
-      }
-    } else {
-      // Task name differs from prerequisite one.
-      // Prerequisite name is the name of sub-task to call.
-      subTaskName = pre.task;
-      subArgs = pre.args;
+      // Fall back to default implementation.
+      return super.callAsPre(planner, pre, details);
     }
 
     // There is a sub-task(s) to execute.

--- a/src/core/tasks/impl/group.task.ts
+++ b/src/core/tasks/impl/group.task.ts
@@ -30,6 +30,7 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
         // Report targets.
         await this._planTargets(
             this.spec.action.targets,
+            pre.task,
             {
               ...planner,
               callPre<TAction extends ZTaskSpec.Action>(
@@ -66,6 +67,7 @@ export class GroupZTask extends AbstractZTask<ZTaskSpec.Group> {
     const batching = this._builder.batching.mergeWith(planner.batching);
     const targets = await this._planTargets(
         this.spec.action.targets,
+        subTaskName,
         {
           ...planner,
           batching,


### PR DESCRIPTION
- Named batches based on reusable selectors mechanics.
- When reusing selector try `batch/task` and `batch/*`
  grouping tasks first.