### PR TITLE
`+cmd:COMMAND` annex support

### DIFF
--- a/src/core/batches/batcher.spec.ts
+++ b/src/core/batches/batcher.spec.ts
@@ -78,9 +78,9 @@ describe('ZBatcher', () => {
       await testPlan.parse('run-z --all other');
 
       expect((await testPlan.callOf(nested1, 'other')).params(ZTaskParams.newEvaluator()).attr('test')).toBe('other');
-      expect(await testPlan.noCallOf(nested1, 'test')).toBeInstanceOf(TypeError);
-      expect(await testPlan.noCallOf(nested2, 'other')).toBeInstanceOf(TypeError);
-      expect(await testPlan.noCallOf(nested2, 'test')).toBeInstanceOf(TypeError);
+      expect(testPlan.findCallOf(nested1, 'test')).toBeUndefined();
+      expect(testPlan.findCallOf(nested2, 'other')).toBeUndefined();
+      expect(testPlan.findCallOf(nested2, 'test')).toBeUndefined();
     });
 
     it('falls back to default batcher if no named batches defined', async () => {
@@ -184,8 +184,8 @@ describe('ZBatcher', () => {
     await testPlan.parse('run-z --all test');
 
     expect((await testPlan.callOf(nested1, 'test')).params(ZTaskParams.newEvaluator()).attr('test')).toBe('main');
-    expect(await testPlan.noCallOf(nested1, 'other')).toBeInstanceOf(TypeError);
+    expect(testPlan.findCallOf(nested1, 'other')).toBeUndefined();
     expect((await testPlan.callOf(nested2, 'test')).params(ZTaskParams.newEvaluator()).attr('test')).toBe('main');
-    expect(await testPlan.noCallOf(nested2, 'other')).toBeInstanceOf(TypeError);
+    expect(testPlan.findCallOf(nested2, 'other')).toBeUndefined();
   }
 });

--- a/src/core/plan/call.impl.ts
+++ b/src/core/plan/call.impl.ts
@@ -138,7 +138,7 @@ export class ZCallRecord<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> im
           // Evaluate parameters.
           const result = ZTaskParams.newMutable();
 
-          ZTaskParams.update(result, this.task.callDetails.params(evaluator));
+          ZTaskParams.update(result, this.task.callDetails(this).params(evaluator));
           for (const [, params] of allParams) {
             ZTaskParams.update(result, params(evaluator));
           }

--- a/src/core/plan/plan.ts
+++ b/src/core/plan/plan.ts
@@ -2,6 +2,7 @@
  * @packageDocumentation
  * @module run-z
  */
+import type { ZPackage } from '../packages';
 import type { ZTask, ZTaskSpec } from '../tasks';
 import type { ZCall } from './call';
 
@@ -23,10 +24,20 @@ export interface ZPlan {
    * @typeparam TAction  Task action type.
    * @param task  Target task.
    *
-   * @returns Either a call to the given task.
+   * @returns A call to the given task.
    *
    * @throws TypeError  If the given task call is not planned.
    */
   callOf<TAction extends ZTaskSpec.Action>(task: ZTask<TAction>): ZCall<TAction>;
+
+  /**
+   * Searches for a call for the task with the given name.
+   *
+   * @param target  Target package.
+   * @param taskName  Task name.
+   *
+   * @returns Either a call to the target task, or `undefined` if the call did not happen.
+   */
+  findCallOf(target: ZPackage, taskName: string): ZCall | undefined;
 
 }

--- a/src/core/plan/planner.impl.ts
+++ b/src/core/plan/planner.impl.ts
@@ -67,7 +67,7 @@ export class ZInstructionRecords {
     } else {
       call = new ZCallRecord(this, by, task, details);
       this._calls.set(task, call);
-      await call._plan(task.callDetails);
+      await call._plan(task.callDetails(call));
     }
     await call._plan(details);
 

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -18,13 +18,15 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
   readonly target: ZPackage;
   readonly name: string;
   readonly taskQN: string;
-  readonly callDetails: ZCallDetails.Full<TAction>;
 
   constructor(protected readonly _builder: ZTaskBuilder$, readonly spec: ZTaskSpec<TAction>) {
     this.target = _builder.taskTarget;
     this.taskQN = this.name = _builder.taskName;
-    this.callDetails = {
-      params: this._callParams.bind(this),
+  }
+
+  callDetails(call: ZCall<TAction>): ZCallDetails.Full<TAction> {
+    return {
+      params: this._callParams.bind(this, call),
       plan: this._planCall.bind(this),
     };
   }
@@ -72,9 +74,11 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
   /**
    * Builds initial task execution parameters.
    *
+   * @param _call  This task call to build parameters for.
+   *
    * @returns Partial task execution parameters.
    */
-  protected _callParams(): ZTaskParams {
+  protected _callParams(_call: ZCall<TAction>): ZTaskParams {
 
     const { spec: { attrs, args } } = this;
 

--- a/src/core/tasks/impl/abstract.task.ts
+++ b/src/core/tasks/impl/abstract.task.ts
@@ -75,10 +75,11 @@ export abstract class AbstractZTask<TAction extends ZTaskSpec.Action> implements
    * Builds initial task execution parameters.
    *
    * @param _call  This task call to build parameters for.
+   * @param _evaluator  Task parameters evaluation context.
    *
    * @returns Partial task execution parameters.
    */
-  protected _callParams(_call: ZCall<TAction>): ZTaskParams {
+  protected _callParams(_call: ZCall<TAction>, _evaluator: ZTaskParams.Evaluator): ZTaskParams {
 
     const { spec: { attrs, args } } = this;
 

--- a/src/core/tasks/impl/command.task.ts
+++ b/src/core/tasks/impl/command.task.ts
@@ -1,6 +1,6 @@
 import type { ZExecution } from '@run-z/exec-z';
 import type { ZJob } from '../../jobs';
-import { ZTaskParams } from '../../plan';
+import { ZCall, ZTaskParams } from '../../plan';
 import type { ZTaskSpec } from '../task-spec';
 import { AbstractZTask } from './abstract.task';
 
@@ -9,11 +9,20 @@ import { AbstractZTask } from './abstract.task';
  */
 export class CommandZTask extends AbstractZTask<ZTaskSpec.Command> {
 
-  protected _callParams(): ZTaskParams {
+  protected _callParams(call: ZCall<ZTaskSpec.Command>, evaluator: ZTaskParams.Evaluator): ZTaskParams {
 
-    const { spec: { attrs, args, action: { args: commandArgs } } } = this;
+    const { spec: { attrs, args, action: { command, args: commandArgs } } } = this;
+    const params = ZTaskParams.newMutable();
 
-    return new ZTaskParams({ attrs, args: [...commandArgs, ...args] });
+    const cmdCall = call.plan.findCallOf(this.target, `cmd:${command}`);
+
+    if (cmdCall) {
+      ZTaskParams.update(params, cmdCall.params(evaluator));
+    }
+
+    ZTaskParams.update(params, { attrs, args: [...commandArgs, ...args] });
+
+    return new ZTaskParams(params);
   }
 
   protected _isParallel(): boolean {

--- a/src/core/tasks/impl/script.task.ts
+++ b/src/core/tasks/impl/script.task.ts
@@ -1,5 +1,6 @@
 import type { ZExecution } from '@run-z/exec-z';
 import type { ZJob } from '../../jobs';
+import { ZCall, ZTaskParams } from '../../plan';
 import type { ZTaskSpec } from '../task-spec';
 import { AbstractZTask } from './abstract.task';
 
@@ -7,6 +8,25 @@ import { AbstractZTask } from './abstract.task';
  * @internal
  */
 export class ScriptZTask extends AbstractZTask<ZTaskSpec.Script> {
+
+  protected _callParams(call: ZCall<ZTaskSpec.Script>, evaluator: ZTaskParams.Evaluator): ZTaskParams {
+
+    const { spec: { attrs, args, action: { command } } } = this;
+    const params = ZTaskParams.newMutable();
+
+    if (command) {
+
+      const cmdCall = call.plan.findCallOf(this.target, `cmd:${command}`);
+
+      if (cmdCall) {
+        ZTaskParams.update(params, cmdCall.params(evaluator));
+      }
+    }
+
+    ZTaskParams.update(params, { attrs, args });
+
+    return new ZTaskParams(params);
+  }
 
   protected _execTask(job: ZJob<ZTaskSpec.Script>): ZExecution {
     return job.shell.execScript(job, this.name);

--- a/src/core/tasks/task-builder.impl.ts
+++ b/src/core/tasks/task-builder.impl.ts
@@ -6,7 +6,7 @@ import type { AbstractZTask } from './impl';
 import { CommandZTask, GroupZTask, ScriptZTask, UnknownZTask } from './impl';
 import type { ZTaskBuilder } from './task-builder';
 import type { ZTaskOption } from './task-option';
-import { ZTaskSpec } from './task-spec';
+import type { ZTaskSpec } from './task-spec';
 import { addZTaskAttr, addZTaskAttrs } from './task-spec.impl';
 
 /**
@@ -76,10 +76,18 @@ export class ZTaskBuilder$<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> 
       }: ZOptionsParser.Opts<ZTaskOption> = {},
   ): Promise<this> {
 
-    const args = this.taskTarget.setup.taskParser.parseCommandLine(commandLine);
+    const args = this.taskTarget.setup.taskParser.parseCommandLine(commandLine, { script: true });
 
-    if (!args) {
-      this.setAction(ZTaskSpec.scriptAction);
+    if (!args || args[0] !== 'run-z') {
+
+      const [command, ...rest] = args || [];
+
+      this.setAction({
+        type: 'script',
+        command,
+        args: rest,
+      });
+
       return this;
     }
 

--- a/src/core/tasks/task-builder.spec.ts
+++ b/src/core/tasks/task-builder.spec.ts
@@ -43,6 +43,31 @@ describe('ZTaskBuilder', () => {
         },
       });
     });
+    it('falls back when task command is not `run-z`', async () => {
+
+      const builder = await newTask({
+        name: 'test',
+        scripts: {
+          test: 'not-run-z attr=val1 --then exec',
+        },
+      });
+
+      await builder.applyArgv('test', ['/usr/bin/node', 'run-z.js', 'attr=val1', '--then', 'exec', 'attr=val2']);
+
+      expect(builder.spec()).toEqual({
+        pre: [],
+        attrs: {
+          attr: ['val1'],
+        },
+        args: [],
+        action: {
+          type: 'command',
+          command: 'exec',
+          parallel: false,
+          args: ['attr=val2'],
+        },
+      });
+    });
     it('falls back when task name absent', async () => {
 
       const builder = await newTask({

--- a/src/core/tasks/task-parser.spec.ts
+++ b/src/core/tasks/task-parser.spec.ts
@@ -5,7 +5,7 @@ import { ZPackage, ZPackageTree } from '../packages';
 import { ZSetup } from '../setup';
 import type { ZTaskBuilder } from './task-builder';
 import { ZTaskParser } from './task-parser';
-import { ZTaskSpec } from './task-spec';
+import type { ZTaskSpec } from './task-spec';
 
 describe('ZTaskParser', () => {
 
@@ -19,25 +19,25 @@ describe('ZTaskParser', () => {
 
     const spec = await parseSpec('some command');
 
-    expect(spec.action).toBe(ZTaskSpec.scriptAction);
+    expect(spec.action).toEqual({ type: 'script', command: 'some', args: ['command'] });
   });
   it('treats task with comment as NPM script', async () => {
 
     const spec = await parseSpec('run-z command #comment');
 
-    expect(spec.action).toBe(ZTaskSpec.scriptAction);
+    expect(spec.action).toEqual({ type: 'script', args: [] });
   });
   it('treats task with shell commands as NPM script', async () => {
 
     const spec = await parseSpec('run-z command > out');
 
-    expect(spec.action).toBe(ZTaskSpec.scriptAction);
+    expect(spec.action).toEqual({ type: 'script', args: [] });
   });
   it('treats task with environment variable substitution as NPM script', async () => {
 
     const spec = await parseSpec('run-z comm${some_env}');
 
-    expect(spec.action).toBe(ZTaskSpec.scriptAction);
+    expect(spec.action).toEqual({ type: 'script', args: [] });
   });
   it('recognizes prerequisites', async () => {
 

--- a/src/core/tasks/task-parser.ts
+++ b/src/core/tasks/task-parser.ts
@@ -96,10 +96,15 @@ export class ZTaskParser {
    * environment variable substitution, or comment.
    *
    * @param commandLine  A command line to parse.
+   * @param script  Whether to allow NPM scripts. When `false` (by default), the command line is rejected, unless
+   * the command is `run-z`.
    *
    * @returns Either parsed command line arguments, or `undefined` if target script can not be parsed.
    */
-  parseCommandLine(commandLine: string): readonly string[] | undefined {
+  parseCommandLine(
+      commandLine: string,
+      { script }: { script?: boolean } = {},
+  ): readonly string[] | undefined {
 
     let withEnv = false;
     const detectEnv = (): undefined => {
@@ -108,8 +113,8 @@ export class ZTaskParser {
     };
     const entries = shellQuote.parse(commandLine, detectEnv);
 
-    if (entries[0] !== 'run-z') {
-      return; // Not a run-z script.
+    if (!script && entries[0] !== 'run-z') {
+      return; // Not a `run-z` command.
     }
     if (withEnv) {
       return; // Environment variable substitution supported in NPM scripts only.

--- a/src/core/tasks/task-spec.ts
+++ b/src/core/tasks/task-spec.ts
@@ -159,7 +159,9 @@ export namespace ZTaskSpec {
 
     readonly type: 'script';
 
-    readonly command?: undefined;
+    readonly command?: string;
+
+    readonly args: readonly string[];
 
   }
 
@@ -201,13 +203,6 @@ const unknownZTaskAction: ZTaskSpec.Unknown = {
   type: 'unknown',
 };
 
-/**
- * @internal
- */
-const scriptZTaskAction: ZTaskSpec.Script = {
-  type: 'script',
-};
-
 export const ZTaskSpec = {
 
   /**
@@ -215,13 +210,6 @@ export const ZTaskSpec = {
    */
   get unknownAction(): ZTaskSpec.Unknown {
     return unknownZTaskAction;
-  },
-
-  /**
-   * NPM script execution task specifier.
-   */
-  get scriptAction(): ZTaskSpec.Script {
-    return scriptZTaskAction;
   },
 
 };

--- a/src/core/tasks/task.ts
+++ b/src/core/tasks/task.ts
@@ -31,9 +31,13 @@ export interface ZTask<TAction extends ZTaskSpec.Action = ZTaskSpec.Action> exte
   readonly spec: ZTaskSpec<TAction>;
 
   /**
-   * Initial details for {@link call calling} this task.
+   * Builds initial details for {@link call calling} this task.
+   *
+   * @param call  This task call to build details of.
+   *
+   * @return Full task call details.
    */
-  readonly callDetails: ZCallDetails.Full<TAction>;
+  callDetails(call: ZCall<TAction>): ZCallDetails.Full<TAction>;
 
     /**
      * Plans a call to this task as a prerequisite of another one.

--- a/src/spec/test-plan.ts
+++ b/src/spec/test-plan.ts
@@ -1,4 +1,3 @@
-import { asis } from '@proc7ts/primitives';
 import type { ZOptionsParser } from '@run-z/optionz';
 import { StandardZSetup } from '../builtins';
 import type { ZCall, ZCallDetails, ZPackageLocation, ZPlan, ZSetup } from '../core';
@@ -71,8 +70,8 @@ export class TestPlan {
     return this.lastPlan.callOf(await target.task(taskName));
   }
 
-  noCallOf(target: ZPackage, taskName: string): Promise<any> {
-    return this.callOf(target, taskName).catch(asis);
+  findCallOf(target: ZPackage, taskName: string): ZCall | undefined {
+    return this.lastPlan.findCallOf(target, taskName);
   }
 
 }


### PR DESCRIPTION
- Make NPM script task spec contain command and args
- Parameterize task call details with the call
- Introduce `ZPlan.findCallOf()` method
- Handle `+cmd:command` task annex
