### PR TITLE
Change progress format

### DIFF
--- a/src/os/system-shell.spec.ts
+++ b/src/os/system-shell.spec.ts
@@ -202,6 +202,19 @@ describe('SystemZShell', () => {
 
         expect(writeSpy).not.toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
       });
+      it('enables text progress format in shorter form', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'no-progress-reporting-task');
+
+        await builder.parse('run-z --color -gtext test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+
+        await call.exec(shell).whenDone();
+
+        expect(writeSpy).not.toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
+      });
     });
 
     describe('--color', () => {
@@ -237,12 +250,46 @@ describe('SystemZShell', () => {
       });
     });
 
+    describe('--color -g', () => {
+      it('enables rich progress format', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
+
+        await builder.parse('run-z --color -g test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+
+        await job.whenDone();
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
+      });
+    });
+
     describe('--no-colors --progress', () => {
       it('enables text progress format', async () => {
 
         const builder = setup.taskFactory.newTask(pkg, 'no-progress-reporting-task');
 
         await builder.parse('run-z --no-colors --progress test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+
+        await job.whenDone();
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.not.stringContaining(logSymbols.success), expect.any(Function));
+      });
+    });
+
+    describe('--no-colors -g', () => {
+      it('enables text progress format', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'no-progress-reporting-task');
+
+        await builder.parse('run-z --no-colors -g test:script', { options: shell.options() });
 
         const task = builder.task();
         const call = await task.call();
@@ -271,6 +318,23 @@ describe('SystemZShell', () => {
       });
     });
 
+    describe('--color -gauto', () => {
+      it('enables rich progress format', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
+
+        await builder.parse('run-z --color -gauto test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+
+        await job.whenDone();
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
+      });
+    });
+
     describe('--no-colors --progress=auto', () => {
       it('enables text progress format', async () => {
 
@@ -288,12 +352,43 @@ describe('SystemZShell', () => {
       });
     });
 
+    describe('--no-colors -gauto', () => {
+      it('enables text progress format', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'no-progress-reporting-task');
+
+        await builder.parse('run-z --no-colors -gauto test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+
+        await job.whenDone();
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.not.stringContaining(logSymbols.success), expect.any(Function));
+      });
+    });
+
     describe('--progress=rich', () => {
       it('enables rich progress format', async () => {
 
         const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
 
         await builder.parse('run-z --no-colors --progress=rich test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+
+        await job.whenDone();
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
+      });
+      it('enables rich progress format in shorter form', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
+
+        await builder.parse('run-z --no-colors -grich test:script', { options: shell.options() });
 
         const task = builder.task();
         const call = await task.call();

--- a/src/os/system-shell.spec.ts
+++ b/src/os/system-shell.spec.ts
@@ -205,11 +205,27 @@ describe('SystemZShell', () => {
     });
 
     describe('--color', () => {
+      it('enables text progress format', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'no-progress-reporting-task');
+
+        await builder.parse('run-z --color test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+
+        await call.exec(shell).whenDone();
+
+        expect(writeSpy).not.toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
+      });
+    });
+
+    describe('--color --progress', () => {
       it('enables rich progress format', async () => {
 
         const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
 
-        await builder.parse('run-z --color test:script', { options: shell.options() });
+        await builder.parse('run-z --color --progress test:script', { options: shell.options() });
 
         const task = builder.task();
         const call = await task.call();
@@ -221,12 +237,12 @@ describe('SystemZShell', () => {
       });
     });
 
-    describe('--no-colors', () => {
+    describe('--no-colors --progress', () => {
       it('enables text progress format', async () => {
 
         const builder = setup.taskFactory.newTask(pkg, 'no-progress-reporting-task');
 
-        await builder.parse('run-z --no-colors test:script', { options: shell.options() });
+        await builder.parse('run-z --no-colors --progress test:script', { options: shell.options() });
 
         const task = builder.task();
         const call = await task.call();
@@ -238,12 +254,12 @@ describe('SystemZShell', () => {
       });
     });
 
-    describe('--progress', () => {
+    describe('--color --progress=auto', () => {
       it('enables rich progress format', async () => {
 
         const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
 
-        await builder.parse('run-z --no-colors --progress test:script', { options: shell.options() });
+        await builder.parse('run-z --color --progress=auto test:script', { options: shell.options() });
 
         const task = builder.task();
         const call = await task.call();
@@ -253,41 +269,14 @@ describe('SystemZShell', () => {
 
         expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
       });
-      it('enables rich progress format without value', async () => {
+    });
 
-        const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
+    describe('--no-colors --progress=auto', () => {
+      it('enables text progress format', async () => {
 
-        await builder.parse('run-z --progress --no-colors test:script', { options: shell.options() });
+        const builder = setup.taskFactory.newTask(pkg, 'no-progress-reporting-task');
 
-        const task = builder.task();
-        const call = await task.call();
-        const job = call.exec(shell);
-
-        await job.whenDone();
-
-        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
-      });
-      it('reports failure', async () => {
-
-        const builder = setup.taskFactory.newTask(pkg, 'error-reporting-task');
-
-        await builder.parse('run-z --progress test:fail', { options: shell.options() });
-
-        const task = builder.task();
-        const call = await task.call();
-        const job = call.exec(shell);
-        const error = await job.whenDone().catch(asis);
-
-        expect(error).toBeInstanceOf(FailedZExecutionError);
-        expect(error.failure).toBe(13);
-
-        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.error), expect.any(Function));
-      });
-      it('displays status when silent task succeeds', async () => {
-
-        const builder = setup.taskFactory.newTask(pkg, 'silently-reporting-task');
-
-        await builder.parse('run-z --progress test:silent', { options: shell.options() });
+        await builder.parse('run-z --no-colors --progress=auto test:script', { options: shell.options() });
 
         const task = builder.task();
         const call = await task.call();
@@ -295,7 +284,7 @@ describe('SystemZShell', () => {
 
         await job.whenDone();
 
-        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(' Ok'), expect.any(Function));
+        expect(writeSpy).toHaveBeenCalledWith(expect.not.stringContaining(logSymbols.success), expect.any(Function));
       });
     });
 
@@ -313,6 +302,50 @@ describe('SystemZShell', () => {
         await job.whenDone();
 
         expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
+      });
+      it('enables rich progress format without colors', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'progress-reporting-task');
+
+        await builder.parse('run-z --progress=rich --no-colors test:script', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+
+        await job.whenDone();
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.success), expect.any(Function));
+      });
+      it('reports failure', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'error-reporting-task');
+
+        await builder.parse('run-z --progress=rich test:fail', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+        const error = await job.whenDone().catch(asis);
+
+        expect(error).toBeInstanceOf(FailedZExecutionError);
+        expect(error.failure).toBe(13);
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(logSymbols.error), expect.any(Function));
+      });
+      it('displays status when silent task succeeds', async () => {
+
+        const builder = setup.taskFactory.newTask(pkg, 'silently-reporting-task');
+
+        await builder.parse('run-z --progress=rich test:silent', { options: shell.options() });
+
+        const task = builder.task();
+        const call = await task.call();
+        const job = call.exec(shell);
+
+        await job.whenDone();
+
+        expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(' Ok'), expect.any(Function));
       });
     });
 

--- a/src/os/system-shell.ts
+++ b/src/os/system-shell.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  * @module run-z
  */
-import { arrayOfElements } from '@proc7ts/primitives';
+import { arrayOfElements, lazyValue } from '@proc7ts/primitives';
 import type { ZExecution, ZExecutionStarter } from '@run-z/exec-z';
 import { poolZExecutions, spawnZ } from '@run-z/exec-z';
 import { zlogDetails, zlogError } from '@run-z/log-z';
@@ -20,12 +20,27 @@ import { RichZProgressFormat } from './impl/rich';
 import { TextZProgressFormat } from './impl/text';
 
 /**
+ * @internal
+ */
+const zProgressFormats = {
+  auto(this: void) {
+    return ttyColorLevel() ? new RichZProgressFormat() : new TextZProgressFormat();
+  },
+  rich(this: void) {
+    return new RichZProgressFormat();
+  },
+  text(this: void) {
+    return new TextZProgressFormat();
+  },
+};
+
+/**
  * Operating system-specific task execution shell.
  */
 export class SystemZShell extends ZShell {
 
   private _exec: (this: void, starter: ZExecutionStarter) => ZExecution = poolZExecutions();
-  private _format?: ZProgressFormat;
+  private _format: (this: void) => ZProgressFormat = lazyValue(zProgressFormats.text);
 
   /**
    * Constructs command line options supported by system shell.
@@ -73,7 +88,7 @@ Defaults to the number of CPUs when no ${clz.param('LIMIT')} set.
         },
         '--progress': {
           read: (option: ZOption) => {
-            this.setProgressFormat('rich');
+            this.setProgressFormat('auto');
             option.recognize();
           },
           meta: {
@@ -83,10 +98,12 @@ Defaults to the number of CPUs when no ${clz.param('LIMIT')} set.
               return `
 ${clz.param('FORMAT')} can be one of:
 
-${clz.bullet()} ${clz.usage('rich')} or none - rich progress format,
+${clz.bullet()} ${clz.usage('rich')} - rich progress format,
 ${clz.bullet()} ${clz.usage('text')} - report progress by logging task output.
+${clz.bullet()} ${clz.usage('auto')} or none - use ${clz.usage('rich')} progress format for color terminals,
+or ${clz.usage('text')} otherwise.
 
-By default ${clz.usage('rich')} format is used for color terminals, and ${clz.usage('text')} otherwise.
+By default ${clz.usage('text')} format is used.
             `;
             },
           },
@@ -96,7 +113,7 @@ By default ${clz.usage('rich')} format is used for color terminals, and ${clz.us
 
             const [name] = option.values();
 
-            this.setProgressFormat(name as 'rich' | 'text');
+            this.setProgressFormat(name as 'rich' | 'text' | 'auto');
           },
           meta: {
             aliasOf: '--progress',
@@ -127,17 +144,22 @@ By default ${clz.usage('rich')} format is used for color terminals, and ${clz.us
    *
    * The following values accepted:
    *
-   * - `rich` or none - rich progress format.
-   * - `text` - reports progress by logging task output.
+   * - `rich` - rich progress format.
+   * - `text` - reports progress by logging task output
+   * - `auto` or none - rich format for color terminals, or text one otherwise.
    *
-   * By default uses `rich` format for color terminals, and `text` otherwise.
+   * By default uses `text` format.
    *
    * @param name  New progress report format name.
    *
    * @returns `this` instance.
    */
-  setProgressFormat(name: 'rich' | 'text'): this {
-    this._format = name === 'text' ? new TextZProgressFormat() : new RichZProgressFormat();
+  setProgressFormat(name: 'rich' | 'text' | 'auto'): this {
+    this._format = name === 'rich'
+        ? lazyValue(zProgressFormats.rich)
+        : name === 'auto'
+            ? lazyValue(zProgressFormats.auto)
+            : lazyValue(zProgressFormats.text);
     return this;
   }
 
@@ -163,11 +185,8 @@ By default ${clz.usage('rich')} format is used for color terminals, and ${clz.us
   }
 
   private _run(job: ZJob, command: string, args: readonly string[]): ZExecution {
-    if (!this._format) {
-      this._format = ttyColorLevel() ? new RichZProgressFormat() : new TextZProgressFormat();
-    }
 
-    const progress = this._format.jobProgress(job);
+    const progress = this._format().jobProgress(job);
 
     return this._exec(() => {
 

--- a/src/os/system-shell.ts
+++ b/src/os/system-shell.ts
@@ -99,9 +99,9 @@ Defaults to the number of CPUs when no ${clz.param('LIMIT')} set.
 ${clz.param('FORMAT')} can be one of:
 
 ${clz.bullet()} ${clz.usage('rich')} - rich progress format,
-${clz.bullet()} ${clz.usage('text')} - report progress by logging task output.
-${clz.bullet()} ${clz.usage('auto')} or none - use ${clz.usage('rich')} progress format for color terminals,
-or ${clz.usage('text')} otherwise.
+${clz.bullet()} ${clz.usage('text')} - report progress by logging task output,
+${clz.bullet()} ${clz.usage('auto')} or none - use ${clz.usage('rich')} format for color terminals, or ${
+                clz.usage('text')} otherwise.
 
 By default ${clz.usage('text')} format is used.
             `;
@@ -119,6 +119,29 @@ By default ${clz.usage('text')} format is used.
             aliasOf: '--progress',
             get usage() {
               return `--progress=${clz.param('FORMAT')}`;
+            },
+          },
+        },
+        '-g': {
+          read: (option: ZOption) => {
+            this.setProgressFormat('auto');
+            option.recognize();
+          },
+          meta: {
+            aliasOf: '--progress',
+          },
+        },
+        '-g*': {
+          read: (option: ZOption) => {
+
+            const [name] = option.values();
+
+            this.setProgressFormat(name as 'rich' | 'text' | 'auto');
+          },
+          meta: {
+            aliasOf: '--progress',
+            get usage() {
+              return `-g${clz.param('FORMAT')}`;
             },
           },
         },


### PR DESCRIPTION
- New `--progress=auto` option value.
- `--progress` without value means the same as `--progress=auto`.
- Add `-g` alias of `--progress` option.
- Use `text` format, unless `--progress` or `-g` specified.
