### PR TITLE
docs(wiki): Migrate GitHub wiki to `docs/usage/wiki` directory in repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 .pnp.*
 
 # Ignore lock files as this project developed within (private) pnpm worktree
+# See issue #57 https://github.com/run-z/run-z/issues/57
 yarn.lock
 package-lock.json
 pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 > See also:
 >
 > -   [API Documentation]
-> -   [Project Wiki](https://github.com/run-z/run-z/wiki)
+> -   [Project Wiki](https://github.com/run-z/run-z/tree/master/docs/usage/wiki)
 > -   [Сборка сложных Node.js проектов утилитой run-z](https://habr.com/ru/post/517506/) (Russian)
 
 [npm-image]: https://img.shields.io/npm/v/run-z.svg?logo=npm

--- a/docs/usage/wiki/partial-builds.md
+++ b/docs/usage/wiki/partial-builds.md
@@ -1,0 +1,32 @@
+# Partial builds
+
+This document describes how to build only a subset of packages.
+
+To control the named batches to include into the build, use these following options:
+
+## `--only <batch>[,<batch>...]` (`-y`)
+
+Limits the build to a set of named batches, where `<batch>` is a batch name (preceding the `/` sign.)
+
+## `--with <batch>[,<batch>...]` (`-w`)
+
+Selects *additional* named batches in addition to the ones specified by `--only`.
+
+Additional named batches have names prefixed by `+` (which is not required in option value).
+
+These additional named batches are not automatically selected,
+unless explictly requested by `--with` or `--only` option.
+
+## `--except <batch>[,<batch>...]` (`-x`)
+
+Excludes the named batches from the build.
+
+This option has higher priority than `--only` and `--with` option,
+which means if a batch is to be included because `--only` or `--with` is used,
+using `--except` would make it excluded from the build instead.
+
+## `--all`
+
+Selects all named batches except *additional* named batches.
+
+When `--all` is used, `--only`, `--with`, and `--except` do not have any effect.

--- a/docs/usage/wiki/reuse-package-selectors.md
+++ b/docs/usage/wiki/reuse-package-selectors.md
@@ -1,0 +1,31 @@
+# Reuse package selectors
+
+You can reuse package selectors from any group task in another task.
+
+Place an ellipsis (`...`) before the name of the group task containing selectors.
+
+## Examples
+
+1.  This can be useful in a root project containing many projects:
+
+    ```
+    {
+      "build": "run-z ...each build",
+      "test": "run-z ...each test --batch-parallel",
+      "each": "run-z ./r3d-party// ./packages//"
+    }
+    ```
+
+2.  You can also reuse package selectors from other packages:
+
+    ```
+    {
+      "build": "run-z ...each build",
+      "test": "run-z ...each test --batch-parallel",
+      "each": "run-z ./r3d-party...each ./packages//"
+    }
+    ```
+
+    As you can see, in this example,
+    an ellipsis (`...`) is placed between
+    the package selector (`./r3d-party`) and the task containing other selectors (`each`).

--- a/docs/usage/wiki/task-annex.md
+++ b/docs/usage/wiki/task-annex.md
@@ -1,0 +1,60 @@
+# Task annex
+
+"Task annex" is a task name prefixed with `+` sign.
+
+It does the same as the task, except the task execution.
+This can be used to pass additional parameters to the task **if** the task executed.
+
+Note that each task would only be executed once.
+Still, it can be specified multiple times, each time with its own set of parameters and attributes.
+
+### Example:
+
+With the following `package.json` file:
+
+```json
+{
+  "scripts": {
+    "test": "run-z +z jest",
+    "z": "run-z +test/--runInBand"
+  }
+}
+```
+
+Executing the `test` `package.json` script would apply the `--runInBand` option to `jest`.
+
+## `+cmd:<command>` annex
+
+Task annexes executing the same binary program may differ.
+
+A special `+cmd:<command>` annex can be used
+to specify additional parameters to a particular binary program.
+`<command>` is the name of the binary program.
+
+### Example
+
+The task for test runner may be called `test`, `test:client` or `test:server`.
+However, they may execute the same binary program as a result:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint .",
+    "test": "run-z test:client test:server",
+    "test:client": "jest -c src/server/jest.config.js",
+    "test:server": "jest -c src/client/jest.config.js"
+  }
+}
+```
+
+In this case, `jest` is executed for both `test` and `test:server`.
+
+To specify additional parameters to `jest`,
+append `+cmd:jest/<parameters>` to the command you use to run npm script:
+
+```shell
+npm test +cmd:jest/--runInBand
+```
+
+The above script would apply `--runInBand` option to all `jest` executions,
+regardless to which one of `test`, `test:client`, or `test:server` was directly invoked.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "clean": "run-z +z --then shx rm -rf 'index.d.ts?(.map)' dist target",
     "doc": "run-z +z --then typedoc",
     "doc:publish": "run-z doc --then gh-pages --dist target/typedoc --dotfiles",
-    "format": "run-z +z --then prettier --write \"**.{json,md}\"",
+    "format": "run-z +z --then prettier --write \"**/*.json\"",
     "lint": "run-z + lint:md --and eslint .",
     "lint:md": "run-z +z --then remark .",
     "test": "run-z +z env:NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" --then jest",


### PR DESCRIPTION
To make wiki editable by contributors.

To fix some issues in wiki.

However, these fixes are incomplete.
Will raise issues on that.